### PR TITLE
debug postcss transform in vue

### DIFF
--- a/lib/webpack-config/addons/add-transform.js
+++ b/lib/webpack-config/addons/add-transform.js
@@ -137,6 +137,13 @@ const makeReactBabelOptions = config => {
   })
 }
 
+function makePostcssOptions({ autoprefixOptions }) {
+  return {
+    plugins: () => [autoprefixer(autoprefixOptions)],
+    ident: 'postcss' // https://github.com/postcss/postcss-loader/issues/281#issuecomment-319089901
+  }
+}
+
 module.exports = (config, key, transform, post) => {
   if (!key || typeof key !== 'string') {
     throw new TypeError(`Invalid transform key: ${JSON.stringify(key)}`)
@@ -164,13 +171,13 @@ module.exports = (config, key, transform, post) => {
     case transforms.css:
     case transforms.less:
     case transforms.sass:
-    case transforms.stylus:
-      const {autoprefixOptions, modules} = transform.config || {}
+    case transforms.stylus: {
+      const { autoprefixOptions, modules } = transform.config || {}
 
-      const postcssOptions = {
-        plugins: [autoprefixer(autoprefixOptions)],
-        ident: 'postcss' // https://github.com/postcss/postcss-loader/issues/281#issuecomment-319089901
-      }
+      const postcssOptions = makePostcssOptions({
+        autoprefixOptions
+      })
+
       const cssOptions = {
         importLoaders: 1,
         modules: !!modules,
@@ -194,8 +201,9 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    case transforms.babel:
+    case transforms.babel: {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
@@ -203,8 +211,9 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    case transforms.jsx:
+    case transforms.jsx: {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
@@ -215,9 +224,10 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
     case transforms.ts:
-    case transforms.tsx:
+    case transforms.tsx: {
       const babelOptions = (
         transform.transformer === transforms.tsx
         ? makeReactBabelOptions(transform.config)
@@ -241,8 +251,9 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    case transforms.flow:
+    case transforms.flow: {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
@@ -250,8 +261,9 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    case transforms.file:
+    case transforms.file: {
       config = update(config, {
         module: { rules: {
           $push: [
@@ -263,21 +275,34 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    case transforms.vue:
+    case transforms.vue: {
       // 首次不处理，其它完成后再处理
       if (!post) break
 
       // 将外部其他的 transform 配置依样画葫芦配置到 vue-loader 里
-      // 保持 vue 文件中对资源的处理逻辑与外部一致
+      // 保持 vue 文件中对资源的处理逻辑与外部一致，除 postcss-loader 的行为外
+      // 已知问题：vue-loader 使用 JSON.stringify 将 loader 的配置序列化，这里
+      // postcss-loader 的配置中 plugins 字段是一个函数列表，函数会被 stringify 为 null
+      // 导致后续执行报错，具体代码见：
+      // https://github.com/vuejs/vue-loader/blob/407ddbd9e442fc8551d662d1709fcffd35419f21/lib/loader.js#L461
+      // 这里把 use 中的 postcss-loader 项干掉，交给 vue-loader 的 style-compiler 调用 postcss 处理
+      const { autoprefixOptions } = transform.config || {}
+      const postcssOptionsInVue = makePostcssOptions({ autoprefixOptions })
+      const loadersInVue = config.module.rules.reduce(
+        (loaders, rule) => {
+          // 把 postcss-loader 的项干掉
+          loaders[rule.__extension__] = rule.use.filter(
+            loader => loader.__loaderName__ !== 'postcss-loader'
+          )
+          return loaders
+        },
+        {}
+      )
       const options = {
-        loaders: config.module.rules.reduce(
-          (loaders, rule) => {
-            loaders[rule.__extension__] = rule.use
-            return loaders
-          },
-          {}
-        )
+        loaders: loadersInVue,
+        postcss: postcssOptionsInVue
       }
       config = update(config, {
         module: { rules: {
@@ -290,8 +315,9 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    case transforms['svg-sprite']:
+    case transforms['svg-sprite']: {
       config = update(config, {
         module: { rules: {
           $push: [
@@ -303,13 +329,15 @@ module.exports = (config, key, transform, post) => {
         } }
       })
       break
+    }
 
-    default:
+    default: {
       config = update(config, {
         module: { rules: {
           $push: [makeRule(extension, context, { loader: transform.transformer, options: transform.config })]
         } }
       })
+    }
   }
 
   return config


### PR DESCRIPTION
postcss 的 plugins 在 vue-loader 里会被 stringify 成 `[null]`，这里对`. vue` 文件中的样式内容不再配置单独的 postcss-loader，而是通过 vue-loader 的 `postcss` 选项传入 postcss 配置，交给 vue-loader 的 style-compiler 调用 postcss 处理。

`.vue` 文件中的样式的 postcss 配置由外部在配置 `vue` 这个 transforms 时指定，而不是使用外部对其它样式内容的 postcss 配置。因为前者是一份，后者是多份，没法自动选择使用后者中某一项。