### PR TITLE
修复 vue-loader 中对样式预处理器的支持问题

### DIFF
--- a/lib/webpack-config/addons/add-transform.js
+++ b/lib/webpack-config/addons/add-transform.js
@@ -72,10 +72,14 @@ const adaptLoader = ({ loader, options }) => {
   loader = makeLoaderName(loader)
   options = loader === 'babel-loader' ? adaptBabelLoaderOptions(options) : options
 
-  const loaderObj = {
-    loader: require.resolve(loader),
-    options
-  }
+  // 这里先前会把 loader 的值通过 `require.resolve` 替换为绝对路径
+  // 目的是为了保证总是能拿到正确的一致的 loader 实现（不受项目本地 node_modules 中 loader 实现的影响）
+  // 但是这样会有一些问题，比如 vue-loader 会通过正则匹配找到其中的 css-loader，而 resolve 后的绝对路径无法
+  // 被匹配（从 vue-loader 的角度也很难实现），见 https://github.com/vuejs/vue-loader/blob/f5b944b3f7bc68d7e4afe7abbb4a8036301f76c0/lib/loader.js#L593
+  // 结果是 vue-loader 不能正确地找到 css-loader 的位置，从而将 style-compiler 插到 less-loader 后边，导致不能正确编译 less 内容
+  // 因此这里先把这个行为干掉，保持 loader 的值为其名字，即（`css-loader`, `less-loader` 这种形式）
+  // `__loaderName__` 仍保留，builder 的实现中优先使用 `__loaderName__` 的值来判断 loader 的类型，而不是 loader 的值
+  const loaderObj = { loader, options }
 
   // 添加 builder 后续处理需要的字段，`enumerable: false` 是为了防止 webpack 乱报错
   // 比如 extract-style 处要根据 `__loaderName__ === 'style-loader'` 判断是否需处理


### PR DESCRIPTION
RT.

潜在风险是，现在 loader 的行为可能会受项目本地依赖的影响，即，不能保证 webpack 用的总是 fec-builder 依赖的 loader 实现