### PR TITLE
remove minimize configuration through LoaderOptionsPlugin

### DIFF
--- a/lib/webpack-config/addons/minimize.js
+++ b/lib/webpack-config/addons/minimize.js
@@ -7,7 +7,11 @@ const webpack = require('webpack')
 
 module.exports = config => {
   config.plugins.push(
-    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.UglifyJsPlugin()/*,
+    // 先不设置这个，因为这个会导致 css-loader（也许是 less-loader？）对 css 内容做压缩
+    // 压缩时会将 /deep/ 前后的空格移除，导致 /deep/ 选择器不能正确地被 vue-loader 识别
+    // 从而导致 /deep/ 对 vue-loader 提供的 scoped css 不生效，具体 /deep/ 的作用见：
+    // https://vue-loader.vuejs.org/zh-cn/features/scoped-css.html#深度作用选择器
     new webpack.LoaderOptionsPlugin({
       minimize: true,
       options: {
@@ -19,7 +23,7 @@ module.exports = config => {
           extensions: config.resolve.extensions
         }
       }
-    })
+    })*/
   )
   return config
 }


### PR DESCRIPTION
先不设置 `LoaderOptionsPlugin`（本来是为了做除 Javascript 内容外其他资源的压缩），因为这个会导致 css-loader（也许是 less-loader？）对 css 内容做压缩，而 css 压缩时会将 /deep/ 前后的空格移除，导致 /deep/ 选择器不能正确地被 vue-loader 识别，从而导致 `/deep/` 对 vue-loader 提供的 scoped css 不生效，具体 `/deep/` 的作用见：
https://vue-loader.vuejs.org/zh-cn/features/scoped-css.html#深度作用选择器

另，经测试，移除该配置后对结果文件的大小影响微乎其微（css 内容 142 KB -> 143 KB，js 内容 1.x MB）