### PR TITLE
解决 Tree Shaking 失效的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,9 @@ npm i fsevents@1.0.17
 ```
 
 待安装成功后重新运行 fec-builder 即可
+
+##### 使用 Typescript 时没有 [Tree Shaking](https://webpack.js.org/guides/tree-shaking/) 的效果
+
+Tree Shaking 功能的生效需要由 Webpack 来处理 ES6 的 module 格式，所以在 Webpack 之前（loader 中）对 ES6 module 进行转换（如转换为 CommonJS 格式）的话，会导致构建没有 Tree Shaking 的效果。如果你在使用 Typescript，很可能是配置 Typescript 输出了 CommonJS 的结果。
+
+修正做法：配置项目根目录下的 `tsconfig.json`，配置其中 `compilerOptions` 中的 `module` 值为 `ES6` 即可；或者不对 `compilerOptions.module` 进行配置，直接配置 `compilerOptions.target` 为 `ES6` 或更高（`ES2016`, `ES2017` 或 `ESNext`）亦可。

--- a/lib/utils/build-env.js
+++ b/lib/utils/build-env.js
@@ -3,7 +3,7 @@
  * @author nighca <nighca@live.cn>
  */
 
-let env = process.env.BUILD_ENV || 'development'
+let env = process.env.BUILD_ENV
 
 /**
  * @desc get build env
@@ -16,7 +16,14 @@ const getEnv = () => env
  * @param  {string} target
  * @return {string}
  */
-const setEnv = (target) => env = target
+const setEnv = (target) => {
+  env = process.env.NODE_ENV = target
+}
+
+// use `development` as default env
+if (!env) {
+  setEnv('development')
+}
 
 module.exports = {
   get: getEnv,


### PR DESCRIPTION
fix #10 
======

* 在设置 build env 时同时配置当前（Node.js 环境）的 `process.env.NODE_ENV` 为对应的值（babel plugin 等工具的行为会依据当前的环境变量，而不是 webpack 的 DefinePlugin 配置进去的环境信息，这里就遇到 `react-hot-loader/babel` 错误地以为当前不是 `production` 环境，从而向结果代码中添加了开发用的辅助代码，导致 webpack 不能正确识别 `unused export` 的情况）
* 针对 Typescript 项目里可能导致 Tree Shaking 失效的情况添加“常见问题”说明