### PR TITLE
 disable host check for dev server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:6.9.1
-MAINTAINER nighca "nighca@live.cn"
+LABEL maintainer="nighca@live.cn"
 
 WORKDIR /fec
 

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -10,7 +10,15 @@ const serve = port => getWebpackConfig().then(
   webpackConfig => {
     const host = '0.0.0.0'
     const webpackDevServerConfig = _.extend(
-      {}, webpackConfig.devServer, { host, port }
+      {}, webpackConfig.devServer, {
+        host,
+        port,
+        // TODO: use false as default value?
+        // for there may be security risk
+        // https://github.com/webpack/webpack-dev-server/issues/882
+        // https://webpack.js.org/configuration/dev-server/#devserver-disablehostcheck
+        disableHostCheck: true
+      }
     )
 
     WebpackDevServer.addDevServerEntrypoints(webpackConfig, webpackDevServerConfig)


### PR DESCRIPTION
Disable host check as default, for convenience of cooperative debug.

More info:
* https://github.com/webpack/webpack-dev-server/issues/882
* https://webpack.js.org/configuration/dev-server/#devserver-disablehostcheck