### PR TITLE
support specifying build config file by CLI arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ npm 包与 docker 镜像的对比，优点：
 
 	作为基础进行扩展的配置信息名，不填写该字段会默认使用 [`default`](https://github.com/Front-End-Engineering-Cloud/builder/blob/master/preset-configs/default.json)，目前可用的内置配置[见此](https://github.com/Front-End-Engineering-Cloud/builder/tree/master/preset-configs)。若该项值置为 `""`，则不会基于任何已有配置进行扩展。
 
+	也可以提供一个本地文件的路径，使用本地配置文件作为被扩展对象，如：`./build-config.base.json`，相对路径会被相对当前配置文件的路径进行解析。
+
 * publicUrl
 
 	静态资源被发布后的线上 URL，一般直接使用存放静态资源的 bucket 对应的公开域名即可，如 `"https://o4jiepyc4.qnssl.com/"`。

--- a/bin/fec-builder
+++ b/bin/fec-builder
@@ -31,6 +31,11 @@ const options = {
     type: 'number',
     default: 80
   },
+  BUILD_CONFIG_FILE: {
+    alias: 'c',
+    desc: 'Path of build config file. If provided, it will be used superior to build-config.json under BUILD_ROOT',
+    type: 'string'
+  },
   ENV_VARIABLES_FILE: {
     alias: 'f',
     desc: 'Target file path for env variables',
@@ -109,6 +114,10 @@ function applyArgv(argv) {
 
   if (argv.BUILD_ROOT) {
     paths.setBuildRoot(argv.BUILD_ROOT)
+  }
+
+  if (argv.BUILD_CONFIG_FILE) {
+    paths.setBuildConfigFilePath(argv.BUILD_CONFIG_FILE)
   }
 
   if (argv.ENV_VARIABLES_FILE) {

--- a/lib/utils/build-conf.js
+++ b/lib/utils/build-conf.js
@@ -77,40 +77,68 @@ const readEnvVariables = (envVariablesFilePath) => {
 }
 
 /**
- * @desc get preset config content with given name
- * @param  {string} name
- * @return {Promise<BuildConfig>}
+ * @desc lookup extends target
+ * @param  {string} name name of extends target
+ * @param  {string} sourceConfigFilePath path of source config file
+ * @return {Promise<string>}
  */
-const getPresetConfig = name => {
-  // TODO: 重新实现
+const lookupExtendsTarget = (name, sourceConfigFilePath) => {
+  logger.debug(`lookup extends target config: ${name}`)
+
   const presetConfigFilePath = path.resolve(__dirname, `../../preset-configs/${name}.json`)
-  const presetConfig = readConfig(presetConfigFilePath)
-  return Promise.resolve(presetConfig)
+  logger.debug(`try preset config: ${presetConfigFilePath}`)
+  if (fs.existsSync(presetConfigFilePath)) {
+    logger.debug(`found preset config: ${presetConfigFilePath}`)
+    return Promise.resolve(presetConfigFilePath)
+  }
+
+  const sourceConfigFileDir = path.dirname(sourceConfigFilePath)
+  const localConfigFilePath = path.resolve(sourceConfigFileDir, name)
+  logger.debug(`try local config: ${localConfigFilePath}`)
+  if (fs.existsSync(localConfigFilePath)) {
+    logger.debug(`found local config: ${localConfigFilePath}`)
+    return Promise.resolve(localConfigFilePath)
+  }
+
+  const localConfigFilePathWithExtension = path.resolve(sourceConfigFileDir, `${name}.json`)
+  logger.debug(`try local config with extension: ${localConfigFilePathWithExtension}`)
+  if (fs.existsSync(localConfigFilePathWithExtension)) {
+    logger.debug(`found local config with extension: ${localConfigFilePathWithExtension}`)
+    return Promise.resolve(localConfigFilePathWithExtension)
+  }
+
+  // TODO: 支持以 npm 包的方式发布 config
+  // 即，这里查找 preset config & local config 失败后，再去尝试 npm package
+
+  const message = `lookup extends target config failed: ${name}`
+  logger.debug(message)
+  return Promise.reject(new Error(message))
 }
 
 /**
- * @desc get config content with given name
- * @param  {string} name
+ * @desc get extends target content
+ * @param  {string} name name of extends target
+ * @param  {string} sourceConfigFilePath path of source config file
  * @return {Promise<BuildConfig>}
  */
-const getConfig = name => {
-  // TODO: 查找策略：根据 name 判断是预设规则还是外部 config
-  return getPresetConfig(name).then(
-    presetConfig => resolveConfig(presetConfig)
+const getExtendsTarget = (name, sourceConfigFilePath) => {
+  return lookupExtendsTarget(name, sourceConfigFilePath).then(
+    configFilePath => readAndResolveConfig(configFilePath)
   )
 }
 
 /**
  * @desc resolve config content by recursively get and merge config to `extends`
- * @param  {BuildConfig} config
+ * @param  {string} configFilePath path of given config
  * @return {Promise<BuildConfig>}
  */
-const resolveConfig = config => {
+const readAndResolveConfig = (configFilePath) => {
+  const config = readConfig(configFilePath)
   const extendsTarget = config.hasOwnProperty('extends') ? config['extends'] : 'default'
   if (!extendsTarget) {
     return Promise.resolve(config)
   }
-  return getConfig(extendsTarget).then(
+  return getExtendsTarget(extendsTarget, configFilePath).then(
     extendsConfig => mergeConfig(extendsConfig, config)
   )
 }
@@ -125,32 +153,34 @@ const findConfig = () => {
   if (cached) {
     return cached
   }
-  return cached = new Promise(resolve => {
-    const configFilePath = paths.abs(files.config)
-    logger.debug(`find build config: ${configFilePath}`)
 
-    const configFileContent = readConfig(configFilePath)
+  // 若指定了 build config file path，则使用之
+  // 否则使用 build root 下的 build config 文件
+  const configFilePath = paths.getBuildConfigFilePath() || paths.abs(files.config)
+  logger.debug(`use build config file: ${configFilePath}`)
 
-    // 若指定了 env variables file path
-    // 读取之并覆盖 build config 中的 envVariables 字段
-    const envVariablesFilePath = paths.getEnvVariablesFilePath()
-    if (envVariablesFilePath) {
-      logger.debug(`find env variables: ${envVariablesFilePath}`)
-      const envVariables = readEnvVariables(envVariablesFilePath)
-      configFileContent.envVariables = envVariables
+  return cached = readAndResolveConfig(configFilePath).then(
+    config => {
+      // 若指定了 env variables file path
+      // 读取之并覆盖 build config 中的 envVariables 字段
+      const envVariablesFilePath = paths.getEnvVariablesFilePath()
+      if (envVariablesFilePath) {
+        logger.debug(`use env variables file: ${envVariablesFilePath}`)
+        const envVariables = readEnvVariables(envVariablesFilePath)
+        config.envVariables = envVariables
+      }
+
+      const isomorphicToolsFilePath = paths.getIsomorphicToolsFilePath()
+      if (isomorphicToolsFilePath) {
+        logger.debug(`use isomorphic-tools file: ${isomorphicToolsFilePath}`)
+        config.isomorphicTools = require(isomorphicToolsFilePath)
+      }
+
+      logger.debug('result build config:')
+      logger.debug(config)
+      return config
     }
-
-    const isomorphicToolsFilePath = paths.getIsomorphicToolsFilePath()
-    if (isomorphicToolsFilePath) {
-      logger.debug(`find isomorphic-tools: ${isomorphicToolsFilePath}`)
-      configFileContent.isomorphicTools = require(isomorphicToolsFilePath)
-    }
-
-    logger.debug('result build config content:')
-    logger.debug(configFileContent)
-
-    resolve(resolveConfig(configFileContent))
-  })
+  )
 }
 
 module.exports = {

--- a/lib/utils/paths.js
+++ b/lib/utils/paths.js
@@ -34,8 +34,22 @@ const setBuildRoot = target => {
  */
 const abs = p => path.resolve(buildRoot, p)
 
+let buildConfigFilePath = process.env.BUILD_CONFIG_FILE || null
 let envVariablesFilePath = process.env.ENV_VARIABLES_FILE || null
 let isomorphicToolsFilePath = process.env.ISOMORPHIC_TOOLS_FILE || null
+
+/**
+ * @desc get build config file path
+ * @return {string}
+ */
+const getBuildConfigFilePath = () => buildConfigFilePath
+
+/**
+ * @desc set build config file path
+ * @param  {string} target
+ * @return {string}
+ */
+const setBuildConfigFilePath = target => buildConfigFilePath = path.resolve(target)
 
 /**
  * @desc get env variables file path
@@ -89,6 +103,8 @@ module.exports = {
   getSrcPath,
   getStaticPath,
   getDistPath,
+  getBuildConfigFilePath,
+  setBuildConfigFilePath,
   getEnvVariablesFilePath,
   setEnvVariablesFilePath,
   getIsomorphicToolsFilePath,

--- a/lib/webpack-config/addons/fork-ts-checker-webpack-plugin.js
+++ b/lib/webpack-config/addons/fork-ts-checker-webpack-plugin.js
@@ -1,12 +1,15 @@
 const update = require('immutability-helper')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const isTypescriptProject = require('../../utils/project').isTypescriptProject
+const logger = require('../../utils/logger')
 
 module.exports = (webpackConfig, options) => {
   if (isTypescriptProject()) {
     webpackConfig = update(webpackConfig, {
       plugins: {
-        $push: [new ForkTsCheckerWebpackPlugin()]
+        $push: [new ForkTsCheckerWebpackPlugin({
+          logger
+        })]
       }
     })
   }


### PR DESCRIPTION
fix #70 

* CLI arg `BUILD_CONFIG_FILE` to specify build config file (superior to `$BUILD_ROOT/build-config.json`)
* support local file path as value of `extends` in build config
* pass logger to fork-ts-checker-webpack-plugin