### PR TITLE
NEW: 增加webpack自定义配置文件路径参数，用于开发时自定义配置，比如devtool

### DIFF
--- a/bin/fec-builder
+++ b/bin/fec-builder
@@ -49,6 +49,11 @@ const options = {
     type: 'boolean',
     desc: 'Output more info',
     default: false
+  },
+  WEBPACK_CONFIG_FILE: {
+    alias: 'w',
+    desc: 'Path of extra webpack config file. If provided, it will be used to extend default webpack config',
+    type: 'string'
   }
 }
 
@@ -126,6 +131,10 @@ function applyArgv(argv) {
 
   if (argv.ISOMORPHIC_TOOLS_FILE) {
     paths.setIsomorphicToolsFilePath(argv.ISOMORPHIC_TOOLS_FILE)
+  }
+
+  if (argv.WEBPACK_CONFIG_FILE) {
+    paths.setWebpackConfigFilePath(argv.WEBPACK_CONFIG_FILE)
   }
 
   if (argv.BUILD_ENV) {

--- a/lib/utils/paths.js
+++ b/lib/utils/paths.js
@@ -37,6 +37,7 @@ const abs = p => path.resolve(buildRoot, p)
 let buildConfigFilePath = process.env.BUILD_CONFIG_FILE || null
 let envVariablesFilePath = process.env.ENV_VARIABLES_FILE || null
 let isomorphicToolsFilePath = process.env.ISOMORPHIC_TOOLS_FILE || null
+let webpackConfigFilePath = process.env.WEBPACK_CONFIG_FILE || null
 
 /**
  * @desc get build config file path
@@ -96,6 +97,19 @@ const getStaticPath = conf => abs(conf.staticDir)
  */
 const getDistPath = conf => abs(conf.distDir)
 
+/**
+* @desc get webpack config file path
+* @return {string}
+*/
+const getWebpackConfigFilePath = () => webpackConfigFilePath
+
+/**
+ * @desc set webpack config file path
+ * @param  {string} target
+ * @return {string}
+ */
+const setWebpackConfigFilePath = target => webpackConfigFilePath = path.resolve(target)
+
 module.exports = {
   abs,
   getBuildRoot,
@@ -108,5 +122,7 @@ module.exports = {
   getEnvVariablesFilePath,
   setEnvVariablesFilePath,
   getIsomorphicToolsFilePath,
-  setIsomorphicToolsFilePath
+  setIsomorphicToolsFilePath,
+  getWebpackConfigFilePath,
+  setWebpackConfigFilePath
 }

--- a/lib/webpack-config/dev.js
+++ b/lib/webpack-config/dev.js
@@ -5,10 +5,24 @@
 
 const getCommonConfig = require('./common')
 
+const fs = require('fs')
+const paths = require('../utils/paths')
+const update = require('immutability-helper')
+
 module.exports = () => getCommonConfig().then(
   config => {
     config = require('./addons/sourcemap')(config)
     config = require('./addons/fork-ts-checker-webpack-plugin')(config)
+    
+    const webpackConfigFilePath = paths.getWebpackConfigFilePath()
+    if (!!webpackConfigFilePath) {
+      const configFileRawContent = fs.readFileSync(webpackConfigFilePath, { encoding: 'utf8' })
+      const configFileContent = JSON.parse(configFileRawContent)
+      config = update(config, {
+        $merge: configFileContent
+      })
+    }
+
     return config
   }
 )


### PR DESCRIPTION
使用方式：
```
fec-builder -p 8080 -w webpack-config.json
```
webpack-config.json内容：
```
{
  "devtool": "eval-source-map"
}
```