### PR TITLE
Production 下 hidden-source-map 改为 source-map

### DIFF
--- a/lib/webpack-config/addons/sourcemap.js
+++ b/lib/webpack-config/addons/sourcemap.js
@@ -22,7 +22,7 @@ module.exports = config => {
   if (buildEnv.get() === buildEnv.prod) {
     return update(config, {
       devtool: {
-        $set: 'hidden-source-map'
+        $set: 'source-map'
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "bin": {
     "fec-builder": "./bin/fec-builder"
   },


### PR DESCRIPTION
两者区别 [https://webpack.js.org/configuration/devtool/]： 
![image](https://user-images.githubusercontent.com/2082295/43461630-8604563a-9506-11e8-83d8-c1b81787ff1f.png)

修改原因：
1. Sentry 解析 sourcemap 时一定要文件尾部带有 ```//# sourceMappingURL=xxx``` 
2. 这个信息带到编译出的文件里不会造成什么不良影响