### PR TITLE
兼容 secure cookie

### DIFF
--- a/lib/webpack-config/addons/configure-proxy.js
+++ b/lib/webpack-config/addons/configure-proxy.js
@@ -33,6 +33,16 @@ const defaultProxyOptions = {
         )
       )
     }
+  },
+
+  onProxyRes(proxyRes, req, res) {
+    // 干掉 set-cookie 中的 secure 设置，因为本地开发 server 是 http 的
+    // TODO: 考虑支持 https dev server？
+    if (proxyRes.headers['set-cookie']) {
+      proxyRes.headers['set-cookie'] = proxyRes.headers['set-cookie'].map(
+        cookie => cookie.replace('; Secure', '')
+      )
+    }
   }
 
 }


### PR DESCRIPTION
如果 devProxy 的目标地址是 HTTPS server，且 API set cookie 时指定 `Secure`，本地的 dev server（目前是 HTTP）无法正确设置 cookie；

这里对 response 做一下修改来去掉 `Secure` 设置