### PR TITLE
use `index.tsx` instead of `index.ts` as index-entry for typescript-react project

### DIFF
--- a/preset-configs/typescript-react.json
+++ b/preset-configs/typescript-react.json
@@ -1,7 +1,7 @@
 {
   "extends": "react",
   "entries": {
-    "index": "src/index.ts"
+    "index": "src/index.tsx"
   },
   "transforms": {
     "ts": "tsx",


### PR DESCRIPTION
一般来说 Typescript + React 项目，入口文件都是 `tsx` 文件：

```tsx
ReactDOM.render(
  <App />,
  document.getElementById('root')
)
```