### PR TITLE
修复 docker build 的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,7 @@ LABEL maintainer="nighca@live.cn"
 
 WORKDIR /fec
 
-# provide both npm 5.x & yarn for user
-
-# prepare for npm upgrade https://github.com/npm/npm/issues/9863
-RUN cd $(npm root -g)/npm \
-  && npm install fs-extra \
-  && sed -i -e s/graceful-fs/fs-extra/ -e s/fs\.rename/fs.move/ ./lib/utils/rename.js
-# upgrade npm
-RUN npm install -g npm@5.4.2
-
+# provide yarn for user
 RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak && \
     echo "deb http://deb.debian.org/debian/ jessie main" >/etc/apt/sources.list && \
     echo "deb-src http://deb.debian.org/debian/ jessie main" >>/etc/apt/sources.list && \

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "bin": {
     "fec-builder": "./bin/fec-builder"
   },


### PR DESCRIPTION
目前的 node 8.16.1 已经内置 npm 6.x，不需要再去安装 npm 5.x