### PR TITLE
Serve 简单处理一下  port 参数为空时的情况、优化日志输出格式

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -19,4 +19,4 @@ const clean = () => findBuildConfig().then(
   }
 )
 
-module.exports = logLifecycle('clean', clean, logger)
+module.exports = logLifecycle('Clean', clean, logger)

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -21,4 +21,4 @@ const generate = () => require('./webpack-config')().then(
   })
 )
 
-module.exports = logLifecycle('generate', generate, logger)
+module.exports = logLifecycle('Generate', generate, logger)

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -6,8 +6,16 @@ const logger = require('./utils/logger')
 const logLifecycle = require('./utils').logLifecycle
 const getWebpackConfig = require('./webpack-config/serve')
 
-const serve = port => getWebpackConfig().then(
+const validPort = (port) => {
+  if (!port) {
+    logger.fatal('Missing server port, exit 1')
+    process.exit(1)
+  }
+}
+
+const serve = (port) => getWebpackConfig().then(
   webpackConfig => {
+    validPort(port)
     const host = '0.0.0.0'
     const webpackDevServerConfig = _.extend(
       {}, webpackConfig.devServer, {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -6,7 +6,7 @@ const logger = require('./utils/logger')
 const logLifecycle = require('./utils').logLifecycle
 const getWebpackConfig = require('./webpack-config/serve')
 
-const validPort = (port) => {
+const validatePort = (port) => {
   if (!port) {
     logger.fatal('Missing server port, exit 1')
     process.exit(1)
@@ -15,7 +15,7 @@ const validPort = (port) => {
 
 const serve = (port) => getWebpackConfig().then(
   webpackConfig => {
-    validPort(port)
+    validatePort(port)
     const host = '0.0.0.0'
     const webpackDevServerConfig = _.extend(
       {}, webpackConfig.devServer, {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -47,4 +47,4 @@ const serve = (port) => getWebpackConfig().then(
   }
 )
 
-module.exports = logLifecycle('serve', serve, logger)
+module.exports = logLifecycle('Serve', serve, logger)

--- a/lib/test.js
+++ b/lib/test.js
@@ -73,4 +73,4 @@ const test = () => {
   )
 }
 
-module.exports = logLifecycle('test', test, logger)
+module.exports = logLifecycle('Test', test, logger)

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -98,4 +98,4 @@ const upload = () => findBuildConfig().then(
   )
 )
 
-module.exports = logLifecycle('upload', upload, logger)
+module.exports = logLifecycle('Upload', upload, logger)


### PR DESCRIPTION
在使用时如果``` -p``` 后面不带参数、服务其实可以正常启动、但是日志输出：
 ```
serve start
...
Starting server on 0.0.0.0:undefined
```
这是因为 ``` webpack-server``` 确实正常启动了、空的参数使``` webpack-server``` 使用了默认端口 ```8080```、但是日志输出没拿到，所以添加个默认参数