### PR TITLE
支持作用范围交叉的 transform 配置

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -29,6 +29,8 @@ const serve = port => getWebpackConfig().then(
     logger.debug(webpackDevServerConfig)
     logger.debug('webpack config:')
     logger.debug(webpackConfig)
+    logger.debug('webpack module rules:')
+    logger.debug(webpackConfig.module.rules)
 
     const compiler = webpack(webpackConfig)
     const server = new WebpackDevServer(compiler, webpackDevServerConfig)

--- a/lib/webpack-config/addons/add-transform.js
+++ b/lib/webpack-config/addons/add-transform.js
@@ -253,7 +253,7 @@ module.exports = (
     excludes.push(makeJsExcludePattern(optimization.transformDeps))
   }
 
-  const contextExcludes = excludedContexts.map(makeExtensionPattern)
+  const contextExcludes = (excludedContexts || []).map(makeExtensionPattern)
 
   const ruleOptions = { extension, context, excludes, contextExcludes }
 

--- a/lib/webpack-config/addons/add-transform.js
+++ b/lib/webpack-config/addons/add-transform.js
@@ -148,13 +148,17 @@ const makeRule = ({ extension, context, excludes, contextExcludes, loaderList })
     configurable: true
   })
 
-  if (context || (contextExcludes && contextExcludes.length > 0)) {
-    rule.issuer = {}
-    if (context) {
-      rule.issuer.test = makeExtensionPattern(context)
+  if (context) {
+    rule.issuer = {
+      ...rule.issuer,
+      test: makeExtensionPattern(context)
     }
-    if (contextExcludes && contextExcludes.length > 0) {
-      rule.issuer.exclude = contextExcludes
+  }
+
+  if (contextExcludes && contextExcludes.length > 0) {
+    rule.issuer = {
+      ...rule.issuer,
+      exclude: contextExcludes
     }
   }
 

--- a/lib/webpack-config/addons/add-transform.js
+++ b/lib/webpack-config/addons/add-transform.js
@@ -135,7 +135,7 @@ const adaptLoader = ({ loader, options }) => {
   return loaderObj
 }
 
-const makeRule = (extension, context, exclude, ...loaderList) => {
+const makeRule = ({ extension, context, excludes, contextExcludes, loaderList }) => {
   const rule = {
     test: makeExtensionPattern(extension),
     use: loaderList.map(adaptLoader)
@@ -148,12 +148,18 @@ const makeRule = (extension, context, exclude, ...loaderList) => {
     configurable: true
   })
 
-  if (context) {
-    rule.issuer = makeExtensionPattern(context)
+  if (context || (contextExcludes && contextExcludes.length > 0)) {
+    rule.issuer = {}
+    if (context) {
+      rule.issuer.test = makeExtensionPattern(context)
+    }
+    if (contextExcludes && contextExcludes.length > 0) {
+      rule.issuer.exclude = contextExcludes
+    }
   }
 
-  if (exclude != null) {
-    rule.exclude = exclude
+  if (excludes && excludes.length > 0) {
+    rule.exclude = excludes
   }
 
   return rule
@@ -205,14 +211,19 @@ function makeJsExcludePattern(transformDeps) {
   return transformDeps ? null : /node_modules\//
 }
 
-module.exports = (config, key, transform, buildConfig, post) => {
-  if (!key || typeof key !== 'string') {
-    throw new TypeError(`Invalid transform key: ${JSON.stringify(key)}`)
+module.exports = (
+  config,
+  {
+    extension,
+    context,
+    excludedExtensions,
+    excludedContexts,
+    transform,
+    buildConfig,
+    post
   }
-
+) => {
   const { targets, optimization } = buildConfig
-  const [extension, context] = key.split('@')
-
   const isTesting = buildEnv.get() === buildEnv.test
 
   if (typeof transform === 'string') {
@@ -231,12 +242,16 @@ module.exports = (config, key, transform, buildConfig, post) => {
     return config
   }
 
+  const excludes = (excludedExtensions || []).map(makeExtensionPattern)
+
   // 针对后缀为 js 的 transform，控制范围（不对依赖做转换）
-  const exclude = (
-    extension === 'js'
-    ? makeJsExcludePattern(optimization.transformDeps)
-    : null
-  )
+  if (extension === 'js') {
+    excludes.push(makeJsExcludePattern(optimization.transformDeps))
+  }
+
+  const contextExcludes = excludedContexts.map(makeExtensionPattern)
+
+  const ruleOptions = { extension, context, excludes, contextExcludes }
 
   switch(transform.transformer) {
     case transforms.css:
@@ -279,7 +294,7 @@ module.exports = (config, key, transform, buildConfig, post) => {
 
       config = update(config, {
         module: { rules: {
-          $push: [makeRule(extension, context, exclude, ...loaders)]
+          $push: [makeRule({ ...ruleOptions, loaderList: loaders })]
         } }
       })
       break
@@ -290,7 +305,10 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
-          $push: [makeRule(extension, context, exclude, { loader: 'babel', options: babelLoaderOptions })]
+          $push: [makeRule({
+            ...ruleOptions,
+            loaderList: [{ loader: 'babel', options: babelLoaderOptions }]
+          })]
         } }
       })
       break
@@ -304,13 +322,16 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
-          $push: [makeRule(extension, context, exclude, {
-            loader: 'babel',
-            options: makeBabelLoaderOptions(
-              makeReactBabelOptions(transformConfig.babelOptions),
-              targets.browsers,
-              optimization
-            )
+          $push: [makeRule({
+            ...ruleOptions,
+            loaderList: [{
+              loader: 'babel',
+              options: makeBabelLoaderOptions(
+                makeReactBabelOptions(transformConfig.babelOptions),
+                targets.browsers,
+                optimization
+              )
+            }]
           })]
         } }
       })
@@ -341,13 +362,13 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
-          $push: [makeRule(
-            extension,
-            context,
-            exclude,
-            { loader: 'babel', options: makeBabelLoaderOptions(babelOptions, targets.browsers, optimization) },
-            { loader: 'ts', options: tsLoaderOptions }
-          )]
+          $push: [makeRule({
+            ...ruleOptions,
+            loaderList: [
+              { loader: 'babel', options: makeBabelLoaderOptions(babelOptions, targets.browsers, optimization) },
+              { loader: 'ts', options: tsLoaderOptions }
+            ]
+          })]
         } }
       })
       break
@@ -358,7 +379,10 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = addDefaultExtension(config, extension)
       config = update(config, {
         module: { rules: {
-          $push: [makeRule(extension, context, exclude, { loader: transform.transformer, options: transform.config })]
+          $push: [makeRule({
+            ...ruleOptions,
+            loaderList: [{ loader: transform.transformer, options: transform.config }]
+          })]
         } }
       })
       break
@@ -368,9 +392,12 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = update(config, {
         module: { rules: {
           $push: [
-            makeRule(extension, context, exclude, {
-              loader: 'file',
-              options: { name: 'static/[name]-[hash].[ext]' }
+            makeRule({
+              ...ruleOptions,
+              loaderList: [{
+                loader: 'file',
+                options: { name: 'static/[name]-[hash].[ext]' }
+              }]
             })
           ]
         } }
@@ -411,10 +438,7 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = update(config, {
         module: { rules: {
           $push: [
-            makeRule(extension, context, exclude, {
-              loader: 'vue',
-              options
-            })
+            makeRule({ ...ruleOptions, loaderList: [{ loader: 'vue', options }] })
           ]
         } }
       })
@@ -425,15 +449,18 @@ module.exports = (config, key, transform, buildConfig, post) => {
       config = update(config, {
         module: { rules: {
           $push: [
-            makeRule(extension, context, exclude, {
-              loader: 'svg-sprite',
-              options: {
-                // TODO:
-                // runtimeCompat 好像要被废弃了: https://github.com/kisenka/svg-sprite-loader/#runtimecompat-default-false-deprecated
-                // 考虑通过 https://github.com/kisenka/svg-sprite-loader/#runtimegenerator-default-generator 实现类似的功能
-                runtimeCompat: true,
-                symbolId: '[name]-[hash]'
-              }
+            makeRule({
+              ...ruleOptions,
+              loaderList: [{
+                loader: 'svg-sprite',
+                options: {
+                  // TODO:
+                  // runtimeCompat 好像要被废弃了: https://github.com/kisenka/svg-sprite-loader/#runtimecompat-default-false-deprecated
+                  // 考虑通过 https://github.com/kisenka/svg-sprite-loader/#runtimegenerator-default-generator 实现类似的功能
+                  runtimeCompat: true,
+                  symbolId: '[name]-[hash]'
+                }
+              }]
             })
           ]
         } }
@@ -444,7 +471,10 @@ module.exports = (config, key, transform, buildConfig, post) => {
     default: {
       config = update(config, {
         module: { rules: {
-          $push: [makeRule(extension, context, exclude, { loader: transform.transformer, options: transform.config })]
+          $push: [makeRule({
+            ...ruleOptions,
+            loaderList: [{ loader: transform.transformer, options: transform.config }]
+          })]
         } }
       })
     }

--- a/lib/webpack-config/common.js
+++ b/lib/webpack-config/common.js
@@ -72,24 +72,50 @@ module.exports = () => findBuildConfig().then(
       }
     }
 
+    const transformConfigs = Object.keys(buildConfig.transforms).map(
+      key => {
+        const [extension, context] = key.split('@')
+        const transform = buildConfig.transforms[key]
+        return {
+          extension,
+          context: context || '',
+          transform,
+          excludedExtensions: null,
+          excludedContexts: null
+        }
+      }
+    )
+
+    // 处理 extension / context 冲突的 transform 项
+    transformConfigs.forEach(transformConfig => {
+      const { extension, context } = transformConfig
+
+      // 若存在其他 extension 比当前 extension 更精确，则在当前项中排除之；
+      // 如 css & module.css，则在 css 对应项中排除 module.css
+      const extensions = transformConfigs.map(({ extension }) => extension)
+      transformConfig.excludedExtensions = extensions.filter(endsWithExt(extension))
+
+      // 若存在其他项 extension 与当前 extension 相同，而 context 更精确，则在当前项中排除之；
+      // 如 svg@css & svg@module.css，则在 svg@css 对应项中排除 svg@module.css
+      const contexts = transformConfigs.filter(
+        targetConfig => targetConfig.extension === extension
+      ).map(({ context }) => context)
+      transformConfig.excludedContexts = contexts.filter(endsWithExt(context))
+    })
+
     // add transforms
-    Object.keys(buildConfig.transforms).forEach(key => {
+    transformConfigs.forEach(transformConfig => {
       webpackConfig = require('./addons/add-transform')(
         webpackConfig,
-        key,
-        buildConfig.transforms[key],
-        buildConfig
+        { ...transformConfig, buildConfig }
       )
     })
 
-    // 有的 transform 的添加逻辑比较特别，需要在别的添加完成后再添加，使用最后一个参数 post 标识
-    Object.keys(buildConfig.transforms).forEach(key => {
+    // 有的 transform 的添加逻辑比较特别，需要在别的添加完成后再添加，使用 post 标识
+    transformConfigs.forEach(transformConfig => {
       webpackConfig = require('./addons/add-transform')(
         webpackConfig,
-        key,
-        buildConfig.transforms[key],
-        buildConfig,
-        true
+        { ...transformConfig, buildConfig, post: true }
       )
     })
 
@@ -102,3 +128,7 @@ module.exports = () => findBuildConfig().then(
     return webpackConfig
   }
 )
+
+function endsWithExt(ext) {
+  return target => target.endsWith('.' + ext)
+}

--- a/lib/webpack-config/common.js
+++ b/lib/webpack-config/common.js
@@ -93,14 +93,18 @@ module.exports = () => findBuildConfig().then(
       // 若存在其他 extension 比当前 extension 更精确，则在当前项中排除之；
       // 如 css & module.css，则在 css 对应项中排除 module.css
       const extensions = transformConfigs.map(({ extension }) => extension)
-      transformConfig.excludedExtensions = extensions.filter(endsWithExt(extension))
+      transformConfig.excludedExtensions = extensions.filter(
+        target => target !== extension && endsWithExt(target, extension)
+      )
 
       // 若存在其他项 extension 与当前 extension 相同，而 context 更精确，则在当前项中排除之；
       // 如 svg@css & svg@module.css，则在 svg@css 对应项中排除 svg@module.css
       const contexts = transformConfigs.filter(
         targetConfig => targetConfig.extension === extension
       ).map(({ context }) => context)
-      transformConfig.excludedContexts = contexts.filter(endsWithExt(context))
+      transformConfig.excludedContexts = contexts.filter(
+        target => target !== context && endsWithExt(target, context)
+      )
     })
 
     // add transforms
@@ -129,6 +133,6 @@ module.exports = () => findBuildConfig().then(
   }
 )
 
-function endsWithExt(ext) {
-  return target => target.endsWith('.' + ext)
+function endsWithExt(target, ext) {
+  return target.endsWith(ext ? ('.' + ext) : '')
 }


### PR DESCRIPTION
支持作用范围交叉的 transform 配置，最精确的会生效，如：

```json
{
  "transforms": {
    "css": "css",
    "m.css": {
      "transformer": "css",
      "config": {
        "modules": true
      }
    },
    "svg@css": "file",
    "svg@m.css": "raw"
  }
}
```

则：

* 对于 `foo.css` 文件： `css`
* 对于 `foo.m.css` 文件：`css` & `modules: true`
* 对于 `foo.css` 文件中引入的 `bar.svg`文件：`file`
* 对于 `foo.m.css` 文件中引入的 `bar.svg` 文件：`raw`
