### PR TITLE
remove babel-preset polyfill configure

### DIFF
--- a/lib/webpack-config/addons/add-transform.js
+++ b/lib/webpack-config/addons/add-transform.js
@@ -53,18 +53,7 @@ const makeBabelLoaderOptions = (options, targets, { addPolyfill }) => {
   const plugins = options.plugins || []
 
   const babelPresetEnvName = '@babel/preset-env'
-  const presetPolyfillOptions = {
-    useBuiltIns: 'entry',
-    // corejs 选项在 @babel/preset-env 7.4.0 之后可用；
-    // 若 @babel/preset-env 版本 >= 7.4.0，则此处需要显式指定版本为 2
-    corejs: 2,
-  }
   const defaultBabelPresetEnv = [babelPresetEnvName, {
-    ...(
-      addPolyfill && buildEnv.get() === buildEnv.prod
-      ? presetPolyfillOptions
-      : null
-    ),
     modules: false,
     targets
   }]


### PR DESCRIPTION
`builder` 当前依赖于 `transform-runtime` 来做 `polyfill` 的工作。好处是 [without global pollution](https://babeljs.io/docs/en/babel-plugin-transform-runtime)。另外，同时配置 `preset` 的 `corejs` 和 `transform-runtime` 的 `corejs` 是不推荐的做法，所以可以把 `preset` 的相关配置去掉..