### PR TITLE
上传行为优化

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -18,36 +18,34 @@ const sourceMapPattern = require('./webpack-config/addons/sourcemap').pattern
 // https://gist.github.com/nighca/6562d098ac01814b6e1c1718b16d4abc
 function batch(process, limit = -1) {
   return function batchProcess(tasks = []) {
-    let results = [], finished = 0, processing = 0
+    let results = [], finished = 0, current = 0
     let rejected = false
 
     function tryProcess(resolve, reject) {
       if (rejected) return
-      if (finished >= tasks.length) {
-        resolve(results)
-        return
-      }
+      if (finished >= tasks.length) return resolve(results)
+      if (current >= tasks.length) return
 
-      const offset = finished + processing
-      const todo = limit > 0 ? limit - processing : tasks.length
-      tasks.slice(offset, offset + todo).forEach((task, i) => {
-        processing++
-        process(task).then(
-          result => {
-            results[offset + i] = result
-            processing--
-            finished++
-            tryProcess(resolve, reject)
-          },
-          err => {
-            reject(err)
-            rejected = true
-          }
-        )
-      })
+      const index = current++
+      process(tasks[index]).then(
+        result => {
+          results[index] = result
+          finished++
+          tryProcess(resolve, reject)
+        },
+        err => {
+          reject(err)
+          rejected = true
+        }
+      )
     }
 
-    return new Promise(tryProcess)
+    return new Promise((resolve, reject) => {
+      const realLimit = limit > 0 ? limit : tasks.length
+      for (let i = 0; i < realLimit; i++) {
+        tryProcess(resolve, reject)
+      }
+    })
   }
 }
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -83,9 +83,7 @@ async function runWithRetry(process, retryTime = 3) {
       error = e
     }
   }
-  if (error != null) {
-    throw error
-  }
+  throw error
 }
 
 async function uploadFile(localFile, bucket, key, mac) {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -15,12 +15,48 @@ const findBuildConfig = require('./utils/build-conf').find
 
 const sourceMapPattern = require('./webpack-config/addons/sourcemap').pattern
 
-const getAllFiles = (baseDir) => {
+// https://gist.github.com/nighca/6562d098ac01814b6e1c1718b16d4abc
+function batch(process, limit = -1) {
+  return function batchProcess(tasks = []) {
+    let results = [], finished = 0, processing = 0
+    let rejected = false
+
+    function tryProcess(resolve, reject) {
+      if (rejected) return
+      if (finished >= tasks.length) {
+        resolve(results)
+        return
+      }
+
+      const offset = finished + processing
+      const todo = limit > 0 ? limit - processing : tasks.length
+      tasks.slice(offset, offset + todo).forEach((task, i) => {
+        processing++
+        process(task).then(
+          result => {
+            results[offset + i] = result
+            processing--
+            finished++
+            tryProcess(resolve, reject)
+          },
+          err => {
+            reject(err)
+            rejected = true
+          }
+        )
+      })
+    }
+
+    return new Promise(tryProcess)
+  }
+}
+
+function getAllFiles(baseDir) {
   return new Promise((resolve, reject) => {
     const walker = walk.walk(baseDir)
     const files = []
 
-    walker.on('error', (root, stat, next) => {
+    walker.on('error', (_, stat) => {
       reject(stat.error)
     })
 
@@ -38,64 +74,67 @@ const getAllFiles = (baseDir) => {
   })
 }
 
-const uploadFile = (localFile, bucket, key, mac) => new Promise(
-  (resolve, reject) => {
-    const options = {
-      scope: bucket + ':' + key
+async function runWithRetry(process, retryTime = 3) {
+  let error = null
+  while (retryTime-- > 0) {
+    try {
+      return await process()
+    } catch (e) {
+      error = e
     }
-    const putPolicy = new qiniu.rs.PutPolicy(options)
-    const uploadToken = putPolicy.uploadToken(mac)
-    const putExtra = new qiniu.form_up.PutExtra()
-    const config = new qiniu.conf.Config()
-    const formUploader = new qiniu.form_up.FormUploader(config)
+  }
+  if (error != null) {
+    throw error
+  }
+}
 
+async function uploadFile(localFile, bucket, key, mac) {
+  const options = {
+    scope: bucket + ':' + key
+  }
+  const putPolicy = new qiniu.rs.PutPolicy(options)
+  const uploadToken = putPolicy.uploadToken(mac)
+  const putExtra = new qiniu.form_up.PutExtra()
+  const config = new qiniu.conf.Config()
+  const formUploader = new qiniu.form_up.FormUploader(config)
+
+  const putFile = () => new Promise((resolve, reject) => {
     formUploader.putFile(uploadToken, key, localFile, putExtra, (err, ret) => {
-      if(err) {
-        reject(err)
+      if(err || ret.error) {
+        reject(err || ret.error)
         return
       }
-      resolve(ret)
+      resolve()
     })
-  }
-)
+  })
 
-const upload = () => findBuildConfig().then(
-  buildConfig => {
-    const deployConfig = buildConfig.deploy.config
-    const distPath = paths.getDistPath(buildConfig)
-    const prefix = getPathFromUrl(buildConfig.publicUrl, false)
+  return runWithRetry(putFile, 3)
+}
 
-    const mac = new qiniu.auth.digest.Mac(deployConfig.accessKey, deployConfig.secretKey)
+async function upload() {
+  const buildConfig = await findBuildConfig()
+  const deployConfig = buildConfig.deploy.config
+  const distPath = paths.getDistPath(buildConfig)
+  const prefix = getPathFromUrl(buildConfig.publicUrl, false)
+  const mac = new qiniu.auth.digest.Mac(deployConfig.accessKey, deployConfig.secretKey)
+  const files = await getAllFiles(distPath)
 
-    return Promise.all([
-      distPath,
-      deployConfig,
-      prefix,
-      mac,
-      getAllFiles(distPath)
-    ])
-  }
-).then(
-  ([distPath, deployConfig, prefix, mac, files]) => Promise.all(
-    files.map(name => {
-      const key = prefix ? `${prefix}/${name}` : name
-      const filePath = path.resolve(distPath, name)
+  const concurrentLimit = 50
+  const batchUploadFile = batch(async name => {
+    const key = prefix ? `${prefix}/${name}` : name
+    const filePath = path.resolve(distPath, name)
 
-      // 排除 sourcemap 文件，不要上传到生产环境 CDN
-      if (sourceMapPattern.test(filePath)) {
-        return logger.info(`[IGNORE] ${filePath}`)
-      }
+    // 排除 sourcemap 文件，不要上传到生产环境 CDN
+    if (sourceMapPattern.test(filePath)) {
+      return logger.info(`[IGNORE] ${filePath}`)
+    }
 
-      return uploadFile(
-        filePath,
-        deployConfig.bucket,
-        key,
-        mac
-      ).then(
-        () => logger.info(`[UPLOAD] ${filePath} -> ${key}`)
-      )
-    })
-  )
-)
+    await uploadFile(filePath, deployConfig.bucket, key, mac)
+    logger.info(`[UPLOAD] ${filePath} -> ${key}`)
+  }, concurrentLimit)
+
+  await batchUploadFile(files)
+  logger.info(`[UPLOAD] ${files.length} files with concurrent limit ${concurrentLimit}`)
+}
 
 module.exports = logLifecycle('Upload', upload, logger)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "1.18.0-beta.1",
+  "version": "1.18.0-beta.2",
   "bin": {
     "fec-builder": "./bin/fec-builder"
   },


### PR DESCRIPTION
一些项目构建本身比较耗时，构建成功后因为偶发的上传问题需要重新构建是一个比较高成本的事情，这里优化下上传行为：

1. 添加上传行为的并发数限制（目前默认为 50），避免在待上传文件很多时占用太多 socket（这个时候也更容易出错）
2. 添加对单个文件的出错重试（最多 3 次）

