### PR TITLE
serve 时监测配置文件变更

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,3 @@
   收益有限，可能影响 builder 的安装，低优先级处理
 
 ### sourcemap
-
-### watch build config change
-
-不是痛点，低优先级处理

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3,24 +3,51 @@
  * @author nighca <nighca@live.cn>
  */
 
+import fs from 'fs'
 import url from 'url'
 import webpack from 'webpack'
 import WebpackDevServer from 'webpack-dev-server'
 import { Config as ProxyConfig } from 'http-proxy-middleware'
 import logger from './utils/logger'
-import { getPageFilename, getPathFromUrl, logLifecycle } from './utils'
+import { getPageFilename, getPathFromUrl, logLifecycle, watchFile } from './utils'
 import { getServeConfig } from './webpack'
 import { BuildConfig, DevProxy, findBuildConfig, watchBuildConfig } from './utils/build-conf'
 import { entries, mapValues } from 'lodash'
+import { abs } from './utils/paths'
+
+// 业务项目的配置文件，变更时需要重启 server
+const projectConfigFiles = [
+  'tsconfig.json'
+]
 
 async function serve(port: number) {
-  let stopServer = await runDevServer(port)
-  const stopWatch = watchBuildConfig(async () => {
-    logger.info('Detected build config change, stoping server...')
-    stopServer?.()
-    stopServer = await runDevServer(port)
+  let stopDevServer = await runDevServer(port)
+
+  async function restartDevServer() {
+    await stopDevServer?.()
+    stopDevServer = await runDevServer(port)
+  }
+
+  const disposers: Array<() => void> = []
+
+  disposers.push(watchBuildConfig(async () => {
+    logger.info('Detected build config change, restarting server...')
+    restartDevServer()
+  }))
+
+  projectConfigFiles.forEach(file => {
+    const filePath = abs(file)
+    if (fs.existsSync(filePath)) {
+      disposers.push(watchFile(filePath, async () => {
+        logger.info(`Detected ${file} change, restarting server...`)
+        restartDevServer()
+      }))
+    }
   })
-  process.on('exit', stopWatch)
+
+  process.on('exit', () => {
+    disposers.forEach(disposer => disposer())
+  })
 }
 
 async function runDevServer(port: number) {

--- a/src/utils/build-conf.ts
+++ b/src/utils/build-conf.ts
@@ -296,10 +296,6 @@ export function setNeedAnalyze(value: boolean) {
   needAnalyze = value
 }
 
-export type Disposer = () => void
-
-export type BuildConfigListener = (config: BuildConfig) => void
-
 /** watch build config, call listener when build config changes */
 export function watchBuildConfig(listener: (config: BuildConfig) => void) {
   const configFilePath = resolveBuildConfigFilePath()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -125,7 +125,7 @@ export function getPageFilename(pageName: string) {
   return `${pageName}.html`
 }
 
-/** 监听文件变化，会对内容做比对，适用于体积较小的文本文件 */
+/** 监听文件内容变化，会对内容做比对，适用于体积较小的文本文件 */
 export function watchFile(filePath: string, listener: (content: string) => void) {
 
   function readFile() {
@@ -134,6 +134,8 @@ export function watchFile(filePath: string, listener: (content: string) => void)
 
   let previousCnt = readFile()
 
+  // 1. debounce 是因为有时候可能会在短时间内触发多次变更事件，这里做下合并
+  // 2. 比较文件内容是因为触发变更事件时文件的内容可能没有其实没有变化，这里假设使用方只关心内容的变化
   const onChange = debounce(() => {
     const currentCnt = readFile()
     if (previousCnt !== currentCnt) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -146,23 +146,3 @@ export function watchFile(filePath: string, listener: (content: string) => void)
   fsWatcher.on('change', onChange)
   return () => fsWatcher.close()
 }
-
-// TODO
-// export function getDefaultExtensions(webpackConfig) {
-//   return webpackConfig.resolve.extensions.map(
-//     extension => extension.replace(/^\./, '')
-//   )
-// }
-
-// TODO
-// function runWebpackCompiler(compiler) {
-//   return new Promise((resolve, reject) => {
-//     compiler.run((err, stats) => {
-//       if (err || stats.hasErrors()) {
-//         reject(err || stats.toJson().errors)
-//         return
-//       }
-//       resolve(stats)
-//     })
-//   })
-// }

--- a/src/webpack/transform.ts
+++ b/src/webpack/transform.ts
@@ -126,7 +126,7 @@ function addTransform(
   }
 
   const appendRule = (previousConfig: Configuration, ruleBase: Partial<RuleSetRule>) => produce(previousConfig, (nextConfig: Configuration) => {
-    const rule = makeRule(resource.include, resourcePattern, contextPattern, ruleBase)
+    const rule = makeRule(extension, resourcePattern, contextPattern, ruleBase)
     nextConfig.module!.rules!.push(rule)
   })
 

--- a/src/webpack/transform.ts
+++ b/src/webpack/transform.ts
@@ -116,7 +116,7 @@ function addTransform(
   }
 
   const resourcePattern = {
-    include: makeExtensionPattern(resource.include),
+    include: makeExtensionPattern(extension),
     exclude: excludePatterns
   }
 


### PR DESCRIPTION
## 改动

* 执行 `serve` 命令时监测配置文件是否发生变更；如发生变更，则重启服务（dev server）
* ~~修复 build samples 的问题，确保 circle CI 运行正常~~ （挪到 #134 做）

## 关于对配置文件的监测

会被 watch 的配置文件目前包括：

1. 当前使用的 build config 文件（默认是项目根目录下的 `build-config.json`）
2. 项目根目录下的 `tsconfig.json`（如果存在的话）

![image](https://user-images.githubusercontent.com/1492263/118583843-4b52ec80-b7c8-11eb-9e13-1065bbe2bc76.png)
