### PR TITLE
Upgrade typescript 4.1.x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10676,9 +10676,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ=="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
     },
     "unescape": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "semver": "^7.3.2",
     "style-loader": "^2.0.0",
     "ts-loader": "^8.0.11",
-    "typescript": "^4.0.5",
+    "typescript": "~4.1.3",
     "walk": "^2.3.14",
     "webpack": "^5.4.0",
     "webpack-bundle-analyzer": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "bin": {
     "fec-builder": "./lib/bin.js"
   },


### PR DESCRIPTION
与本次升级中的其他项目（fe-core / portal-base 等）一致，使用 4.1.x 版本的 typescript

参考 https://github.com/qbox/fe-core/pull/129 https://github.com/qbox/portal-base/pull/531