### PR TITLE
精简输出的 log 

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2030,6 +2030,14 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "requires": {
+        "type-fest": "^0.21.3"
+      }
+    },
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -2878,6 +2886,11 @@
         }
       }
     },
+    "ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A=="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3068,6 +3081,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
+    },
+    "consola": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -4465,6 +4483,14 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-uri-to-path": {
@@ -9101,6 +9127,11 @@
         "renderkid": "^2.0.4"
       }
     },
+    "pretty-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
+      "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -10230,6 +10261,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "std-env": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-2.3.0.tgz",
+      "integrity": "sha512-4qT5B45+Kjef2Z6pE0BkskzsH0GO7GrND0wGlTM1ioUe3v0dGYx9ZJH0Aro/YyA8fqQ5EyIKDRjZojJYMFTflw==",
+      "requires": {
+        "ci-info": "^3.0.0"
+      }
+    },
     "streamroller": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
@@ -10500,6 +10539,11 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
     "thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -10665,6 +10709,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -11441,6 +11490,32 @@
       "requires": {
         "source-list-map": "^2.0.1",
         "source-map": "^0.6.1"
+      }
+    },
+    "webpackbar": {
+      "version": "5.0.0-3",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.0-3.tgz",
+      "integrity": "sha512-viW6KCYjMb0NPoDrw2jAmLXU2dEOhRrtku28KmOfeE1vxbfwCYuTbTaMhnkrCZLFAFyY9Q49Z/jzYO80Dw5b8g==",
+      "requires": {
+        "ansi-escapes": "^4.3.1",
+        "chalk": "^4.1.0",
+        "consola": "^2.15.0",
+        "figures": "^3.2.0",
+        "pretty-time": "^1.1.0",
+        "std-env": "^2.2.1",
+        "text-table": "^0.2.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "webpack": "^5.4.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-dev-server": "^3.11.0",
+    "webpackbar": "^5.0.0-3",
     "yargs": "^16.1.1"
   },
   "devDependencies": {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -66,7 +66,7 @@ async function runDevServer(port: number) {
     // 即可能配置 port 为 80，在（宿主机）浏览器中通过 8080 端口访问
     public: '0.0.0.0:0',
     publicPath: getPathFromUrl(buildConfig.publicUrl),
-    stats: webpackConfig.stats,
+    stats: 'errors-only',
     proxy: getProxyConfig(buildConfig.devProxy),
     historyApiFallback: {
       rewrites: getHistoryApiFallbackRewrites(buildConfig)

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -8,6 +8,7 @@ import ReactFastRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
+import WebpackBarPlugin from 'webpackbar'
 import { getBuildRoot, abs, getStaticPath, getDistPath, getSrcPath } from '../utils/paths'
 import { BuildConfig, findBuildConfig, getNeedAnalyze } from '../utils/build-conf'
 import { addTransforms, appendCacheGroups, parseOptimizationConfig } from './transform'
@@ -109,7 +110,8 @@ export async function getConfig(): Promise<Configuration> {
     config,
     ...htmlPlugins,
     definePlugin,
-    staticDirCopyPlugin
+    staticDirCopyPlugin,
+    new WebpackBarPlugin({ color: 'green' })
   )
 
   if (getEnv() === Env.Prod) {


### PR DESCRIPTION
* 使用插件 `webpackbar` 做编包进度条展示
  * 插件源码 https://github.com/unjs/webpackbar/blob/master/src/webpackbar.ts#L167  ， 做的事情主要是从 webpack context 中拿到 stats 及 percentage 进行格式化展示，耗时基本无差别。
  * 插件内部有区分 `tty` 环境进行展示，非 `tty` 环境不展示进度条
* 将 `webpack-dev-server` 的 日志输出设置成了 `errors-only`
  * 对带上 `verbose` 参数的行为无影响


下面以 `portal-platform` 为例：

before:
* 耗时
  * 运行 `fec-builder -p 8080`:  13236 ms
  * 运行 `fec-builder -e production generate`：48s 222ms

进行中像卡住了一样
![image](https://user-images.githubusercontent.com/4157823/122040393-53736b80-ce0a-11eb-8943-e3fc7aee3a81.png)

![image](https://user-images.githubusercontent.com/4157823/122040125-08f1ef00-ce0a-11eb-8c9e-c74cb0218299.png)

遇到错误时
![image](https://user-images.githubusercontent.com/4157823/122040173-160ede00-ce0a-11eb-88a9-074711397b0f.png)


after:
* 耗时
  * 运行 `fec-builder -p 8080`: 13.15s
  * 运行 `fec-builder -e production generate`：45s 186ms

![image](https://user-images.githubusercontent.com/4157823/122038661-6b49f000-ce08-11eb-9a74-ddeb389c250e.png)

![image](https://user-images.githubusercontent.com/4157823/122038767-887ebe80-ce08-11eb-85ea-f8e66a4f4812.png)
