### PR TITLE
修复 Typescript 项目 `moduleResolution` 的问题

### DIFF
--- a/src/webpack/transform.ts
+++ b/src/webpack/transform.ts
@@ -249,7 +249,9 @@ function addTransform(
         // 这里设置为 ESNext（最新的规范能力），进一步的转换由 babel 处理
         target: 'ESNext',
         // enable tree-shaking，由 webpack 来做 module 格式的转换
-        module: 'ESNext'
+        module: 'ESNext',
+        // module 为 ESNext 时，moduleResolution 默认为 Classic（虽然 TS 文档不是这么说的），这里明确指定为 Node
+        moduleResolution: 'Node'
       }
       const tsLoaderOptions = {
         transpileOnly: getEnv() === Env.Dev && transformConfig.transpileOnlyWhenDev,


### PR DESCRIPTION
#143 调整 `module` 为 `ESNext` 时，把 `moduleResolution: 'Node'` 去掉了

后来发现，虽然 Typescript 文档说 `module` 为 `ES2015` 时，`moduleResolution` 默认为 `Classic`，事实上在 `module: 'ESNext'` 是，`moduleResolution` 也默认是 `Classic`，因此还是需要添加指定 `moduleResolution: 'Node'` 的逻辑