### PR TITLE
Extract dynamic import chunk and support  filesystem cache

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "fec-builder",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fec-builder",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "@babel/core": "^7.12.3",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
@@ -44,7 +44,7 @@
         "ts-loader": "^9.2.4",
         "typescript": "~4.1.3",
         "walk": "^2.3.14",
-        "webpack": "^5.13.0",
+        "webpack": "^5.52.0",
         "webpack-bundle-analyzer": "^4.4.1",
         "webpack-dev-server": "^3.11.0",
         "webpackbar": "^5.0.0-3",
@@ -2497,6 +2497,14 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
+      "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-walk": {
@@ -16957,9 +16965,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.46.0.tgz",
-      "integrity": "sha512-qxD0t/KTedJbpcXUmvMxY5PUvXDbF8LsThCzqomeGaDlCA6k998D8yYVwZMvO8sSM3BTEOaD4uzFniwpHaTIJw==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.52.0.tgz",
+      "integrity": "sha512-yRZOat8jWGwBwHpco3uKQhVU7HYaNunZiJ4AkAVQkPCUGoZk/tiIXiwG+8HIy/F+qsiZvSOa+GLQOj3q5RKRYg==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -16967,6 +16975,7 @@
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
         "acorn": "^8.4.1",
+        "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.8.0",
@@ -16983,7 +16992,7 @@
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
         "watchpack": "^2.2.0",
-        "webpack-sources": "^2.3.1"
+        "webpack-sources": "^3.2.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -17532,13 +17541,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
-      "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
-      "dependencies": {
-        "source-list-map": "^2.0.1",
-        "source-map": "^0.6.1"
-      },
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
+      "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
       "engines": {
         "node": ">=10.13.0"
       }
@@ -19743,6 +19748,12 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
       "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
+    },
+    "acorn-import-assertions": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
+      "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.1.0",
@@ -30713,9 +30724,9 @@
       }
     },
     "webpack": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.46.0.tgz",
-      "integrity": "sha512-qxD0t/KTedJbpcXUmvMxY5PUvXDbF8LsThCzqomeGaDlCA6k998D8yYVwZMvO8sSM3BTEOaD4uzFniwpHaTIJw==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.52.0.tgz",
+      "integrity": "sha512-yRZOat8jWGwBwHpco3uKQhVU7HYaNunZiJ4AkAVQkPCUGoZk/tiIXiwG+8HIy/F+qsiZvSOa+GLQOj3q5RKRYg==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -30723,6 +30734,7 @@
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
         "acorn": "^8.4.1",
+        "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.8.0",
@@ -30739,7 +30751,7 @@
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
         "watchpack": "^2.2.0",
-        "webpack-sources": "^2.3.1"
+        "webpack-sources": "^3.2.0"
       },
       "dependencies": {
         "@types/json-schema": {
@@ -31176,13 +31188,9 @@
       }
     },
     "webpack-sources": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
-      "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
-      "requires": {
-        "source-list-map": "^2.0.1",
-        "source-map": "^0.6.1"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
+      "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw=="
     },
     "webpackbar": {
       "version": "5.0.0-3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "2.1.0",
+  "version": "2.1.0-beta.1",
   "bin": {
     "fec-builder": "./lib/bin.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "bin": {
     "fec-builder": "./lib/bin.js"
   },
@@ -50,7 +50,7 @@
     "ts-loader": "^9.2.4",
     "typescript": "~4.1.3",
     "walk": "^2.3.14",
-    "webpack": "^5.13.0",
+    "webpack": "^5.52.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-dev-server": "^3.11.0",
     "webpackbar": "^5.0.0-3",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -48,7 +48,7 @@ const options: Record<string, yargs.Options> = {
     desc: 'Output more info',
     default: false
   },
-  cache: {
+  'unstable-cache': {
     type: 'boolean',
     desc: 'Cache the generated webpack modules and chunks to filesystem for improve build speed. ',
     default: false
@@ -124,7 +124,7 @@ function applyArgv(argv: yargs.Arguments) {
     }
   }
 
-  if (argv.cache) {
+  if (argv['unstable-cache']) {
     setNeedCache()
   }
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,7 +3,7 @@
 import { setAutoFreeze } from 'immer'
 import yargs from 'yargs'
 
-import { setBuildRoot, setBuildConfigFilePath } from './utils/paths'
+import { setBuildRoot, setBuildConfigFilePath, setNeedCache } from './utils/paths'
 import { Env, setEnv } from './utils/build-env'
 import logger from './utils/logger'
 import prepare from './prepare'
@@ -46,6 +46,11 @@ const options: Record<string, yargs.Options> = {
   verbose: {
     type: 'boolean',
     desc: 'Output more info',
+    default: false
+  },
+  cache: {
+    type: 'boolean',
+    desc: 'Cache the generated webpack modules and chunks to filesystem for improve build speed. ',
     default: false
   }
 }
@@ -117,6 +122,10 @@ function applyArgv(argv: yargs.Arguments) {
     } else {
       setEnv(argv.BUILD_ENV as Env)
     }
+  }
+
+  if (argv.cache) {
+    setNeedCache()
   }
 }
 

--- a/src/clean.ts
+++ b/src/clean.ts
@@ -9,12 +9,20 @@ import { getDistPath } from './utils/paths'
 import logger from './utils/logger'
 import { logLifecycle } from './utils'
 import { findBuildConfig } from './utils/build-conf'
+import { getNeedCache, getCachePath } from './utils/paths'
 
 async function clean() {
   const buildConfig = await findBuildConfig()
   const dist = getDistPath(buildConfig)
   logger.debug(`clean dist: ${dist}`)
   await del(dist, { force: true })
+
+  // delete webpack persistent cache directory
+  if (getNeedCache()) {
+    const cacheDir = getCachePath()
+    logger.debug(`clean cache: ${cacheDir}`)
+    await del(cacheDir, { force: true })
+  }
 }
 
 export default logLifecycle('Clean', clean, logger)

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -57,6 +57,11 @@ export function getTestDistPath(conf: BuildConfig) {
   return path.join(getDistPath(conf), '.test')
 }
 
+/** get webpack cache path */
+export function getCachePath() {
+  return abs('node_modules/.cache/webpack')
+}
+
 /** whether need filesystem cache */
 let cache = false
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -56,3 +56,14 @@ export function getDistPath(conf: BuildConfig) {
 export function getTestDistPath(conf: BuildConfig) {
   return path.join(getDistPath(conf), '.test')
 }
+
+/** whether need filesystem cache */
+let cache = false
+
+export function getNeedCache() {
+  return cache
+}
+
+export function setNeedCache() {
+  cache = true
+}

--- a/src/utils/webpack.ts
+++ b/src/utils/webpack.ts
@@ -108,7 +108,7 @@ export function parseOptimizationConfig(optimization: Optimization): {
 
       cacheGroups[chunks.vendor] = {
         name: chunks.vendor,
-        chunks: 'all',
+        chunks: 'initial',
         priority: -10,
         test: function(module: { resource?: string }): boolean {
           const resource = module.resource
@@ -131,7 +131,7 @@ export function parseOptimizationConfig(optimization: Optimization): {
     baseChunks.push(chunks.common)
     cacheGroups[chunks.common] = {
       name: chunks.common,
-      chunks: 'all',
+      chunks: 'initial',
       minChunks: 2,
       priority: -20
     }
@@ -191,6 +191,15 @@ export function addDefaultExtension(config: Configuration, extension: string) {
     const extensions = resolve.extensions = resolve.extensions || []
     if (!extensions.includes(extension)) {
       extensions.push(extension)
+    }
+  })
+}
+
+/** 开启文件缓存 */
+export function enableFilesystemCache(config: Configuration): Configuration {
+  return produce(config, newConfig => {
+    newConfig.cache = {
+      type: 'filesystem'
     }
   })
 }

--- a/src/utils/webpack.ts
+++ b/src/utils/webpack.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { Configuration, WebpackPluginInstance, Chunk, RuleSetRule, RuleSetConditionAbsolute } from 'webpack'
 import chunks from '../constants/chunks'
 import { Optimization } from './build-conf'
+import { getCachePath } from './paths'
 
 /** 向配置中追加 plugin */
 export function appendPlugins(config: Configuration, ...plugins: Array<WebpackPluginInstance | null | undefined>) {
@@ -199,7 +200,8 @@ export function addDefaultExtension(config: Configuration, extension: string) {
 export function enableFilesystemCache(config: Configuration): Configuration {
   return produce(config, newConfig => {
     newConfig.cache = {
-      type: 'filesystem'
+      type: 'filesystem',
+      cacheDirectory: getCachePath()
     }
   })
 }


### PR DESCRIPTION
### 改动点
  * 🌈 `webpack` 版本由 5.13.0 升级至 5.52.0
  * ✨  dynamic import node_modules 下的包时，输出独立的 chunk bundle
    * 改动方式是将 `splitChunks` 插件的 `chunks` 参数由 `all` 改为 `initial`，即 `dynamic import` 的 chunk 不会全部抽取到 `vendor` 里，但公共的依赖仍然会抽到 `vendor`
  * ✨ 增加 `--cache` 命令参数以启用 filesystem cache，对大型的前端仓库的打包速度提升比较明显
    * 之所以新增一个命令而不是默认开启，如官方的描述 filesystem cache 可能是不安全的（我目前测试下来未发现具体的 bug），所以选择稳定性大于性能的诉求，不设置为默认值的详细原因见第一个参考文档
    * 如遇到不预期的现象时需要手动清空缓存，可通过 `fec-builder clean --unstable-cache` 命令来操作

### 参考文档
1. https://github.com/webpack/changelog-v5/blob/master/guides/persistent-caching.md
2. https://webpack.js.org/configuration/cache
3. https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks

### 测试用例
使用 filesystem cache 时 portal-fusion 第一次打包会比不启用缓存慢一点，但后面二次打包可以稳定在 10s 以下

![image](https://user-images.githubusercontent.com/4157823/132122229-18eec419-fcb8-4506-9114-0e0342286c09.png)

![image](https://user-images.githubusercontent.com/4157823/132122235-a5d40f1f-aeee-4265-ac2d-148791dd5e80.png)

dynamic import 打包测试是使用的 portal-pili
![image](https://user-images.githubusercontent.com/4157823/132122281-2ae3a635-ff86-4373-8fae-83b366b0f2e0.png)



