### PR TITLE
支持基于 File System 的 Web 应用

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15971,6 +15971,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
       "dependencies": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -71,6 +71,8 @@ export function getPathFromUrl(
   /** if with slash at begining & ending */
   withSlash = true
 ) {
+  // 支持一下 `./` 形式的 url，暂不考虑 `../` 的情况
+  targetUrl = targetUrl.replace(/^\.\//, '\/')
   const parsed = parseUrl(targetUrl)
   const pathWithoutSlash = (parsed.pathname || '').replace(/^\/|\/$/g, '')
   return (


### PR DESCRIPTION
通过支持

```json
{
  "publicUrl": "./",
}
```

builder 允许我们构建出一个不依赖 HTTP server，基于 File System 就能运行的应用

即，浏览器通过类似 `file:///Users/yanghanxing/Downloads/dist/index.html#/file` 这样的地址来打开页面，页面再通过 `./` 开头的相对路径引入其他静态资源

