### PR TITLE
修复 dev serve 启动日志顺序问题

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -75,10 +75,17 @@ async function runDevServer(port: number) {
   const compiler = webpack(webpackConfig)
   const server = new WebpackDevServer(compiler, devServerConfig)
 
+  await new Promise<void>(resolve => {
+    compiler.hooks.done.tap('DoneHook', () => {
+      resolve()
+    })
+  })
+
   const host = '0.0.0.0'
   server.listen(port, host, () => {
     logger.info(`Server started on ${host}:${port}`)
   })
+
   return () => new Promise<void>(resolve => {
     server.close(resolve)
   })


### PR DESCRIPTION
调整为 `webpack` 启动之后再启动 `webpack-dev-server`

![image](https://user-images.githubusercontent.com/4157823/140016342-e50e5089-e7f3-4e91-9e77-e47896230e15.png)

![image](https://user-images.githubusercontent.com/4157823/140016282-33c49bae-f65e-4f78-9679-cf6ab3cc034b.png)
