### PR TITLE
修复 SVG 文件处理的问题

### DIFF
--- a/src/utils/svgo.ts
+++ b/src/utils/svgo.ts
@@ -9,9 +9,10 @@ import { createHash } from 'crypto'
 // 以避免不同 SVG 文件同时被 inline 到 DOM 中时产生的定义冲突
 const prefixIdsConfig = {
   // https://github.com/svg/svgo/blob/v1.3.2/plugins/prefixIds.js#L126
-  prefix: (_node: any, info: any) => {
-    // `info.path` 值是 svg 文件的绝对路径
-    const hash = createHash('sha1').update(info.path).digest('base64') // TODO: maybe with cache?
+  prefix: (_node: any, extra: any) => {
+    const path = extra && extra.path // svg 文件的绝对路径
+    if (!path) return false
+    const hash = createHash('sha1').update(path).digest('base64') // TODO: maybe with cache?
     return hash.replace(/[^\w]/g, '').slice(0, 10)
   }
 }

--- a/src/utils/svgo.ts
+++ b/src/utils/svgo.ts
@@ -1,0 +1,101 @@
+/**
+ * @file svgo utils
+ * @desc svgo 配置相关逻辑
+ */
+
+import { createHash } from 'crypto'
+
+// `prefixIds` 通过给 SVG 中的 id 值添加 hash 作为前缀，
+// 以避免不同 SVG 文件同时被 inline 到 DOM 中时产生的定义冲突
+const prefixIdsConfig = {
+  // https://github.com/svg/svgo/blob/v1.3.2/plugins/prefixIds.js#L126
+  prefix: (_node: any, info: any) => {
+    // `info.path` 值是 svg 文件的绝对路径
+    const hash = createHash('sha1').update(info.path).digest('base64') // TODO: maybe with cache?
+    return hash.replace(/[^\w]/g, '').slice(0, 10)
+  }
+}
+
+/**
+ * 对 svgo 的配置（用于 svgr，对应 svgo 1.x）
+ * 目前使用的 svgr 版本依赖 svgo 1.x，而 imagemin 依赖 svgo 2.x，二者配置格式不同，
+ * 因此这里分别维护之：`getSvgoConfigForSvgr` & `svgoConfigForImagemin`；
+ * TODO: 待 svgr 正式版依赖 svgo 2.x 后，升级 svgr，这里可以统一二者关于 svgo 的配置（`prefixIds` 除外）
+ */
+export function getSvgoConfigForSvgr(compress: boolean) {
+  if (!compress) {
+    return {
+      full: true, // 干掉 svgo 的默认配置 https://github.com/svg/svgo/blob/v1.3.2/lib/svgo/config.js#L23-L29
+      plugins: [{ prefixIds: prefixIdsConfig }] // 只做 `prefixIds` 的事情（`prefixIds` 会影响展示的正确性）
+    }
+  }
+  return {
+    full: true, // 干掉 svgo 的默认配置 https://github.com/svg/svgo/blob/v1.3.2/lib/svgo/config.js#L23-L29
+    plugins: [
+      // 注意这里格式上不能写成 `['cleanupAttrs', 'removeDoctype', ...]`，
+      // 那样经过 @svgr/plugin-svgo 处理后的配置中 `plugins` 值会不对
+      { cleanupAttrs: true },
+      { removeDoctype: true },
+      { removeXMLProcInst: true },
+      { removeComments: true },
+      { removeMetadata: true },
+      { removeTitle: true },
+      { removeDesc: true },
+      { removeUselessDefs: true },
+      { removeEditorsNSData: true },
+      { removeEmptyAttrs: true },
+      { removeHiddenElems: true },
+      { removeEmptyText: true },
+      { removeEmptyContainers: true },
+      { cleanupEnableBackground: true },
+      { minifyStyles: true },
+      { convertColors: true },
+      { convertPathData: true },
+      { convertTransform: true },
+      { removeUnusedNS: true },
+      { cleanupIDs: {
+        // 注意这里如果开启 minify，需要确保 plugin `cleanupIDs` 在 plugin `prefixIds` 前执行
+        // 否则 `prefixIds` 的结果会被 `cleanupIDs` minify 给改掉，失去 prefix 的效果
+        // 因为这里 svgr 通过 @svgr/plugin-svgo 处理 svgo 配置，其默认配置逻辑（ https://github.com/gregberge/svgr/blob/v5.5.0/packages/plugin-svgo/src/config.js#L9 ）
+        // 会导致 plugin `prefixIds` 最终总会被放到最前面，对应地执行于 plugin `cleanupIDs` 之前
+        // 因此这里先把 minify 关掉
+        minify: false,
+        remove: true
+      } },
+      { prefixIds: prefixIdsConfig },
+      { cleanupNumericValues: true },
+      { collapseGroups: true },
+      { mergePaths: true }
+    ]
+  }
+}
+
+/** 对 svgo 的配置（用于 imagemin，对应 svgo 2.x） */
+export const svgoConfigForImagemin = {
+  plugins: [
+    'cleanupAttrs',
+    'mergeStyles',
+    'removeDoctype',
+    'removeXMLProcInst',
+    'removeComments',
+    'removeMetadata',
+    'removeTitle',
+    'removeDesc',
+    'removeUselessDefs',
+    'removeEditorsNSData',
+    'removeEmptyAttrs',
+    'removeHiddenElems',
+    'removeEmptyText',
+    'removeEmptyContainers',
+    'cleanupEnableBackground',
+    'minifyStyles',
+    'convertColors',
+    'convertPathData',
+    'convertTransform',
+    'removeUnusedNS',
+    'cleanupIDs',
+    'cleanupNumericValues',
+    'collapseGroups',
+    'mergePaths'
+  ]
+}

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -12,11 +12,12 @@ import WebpackBarPlugin from 'webpackbar'
 import ImageMinimizerPlugin from 'image-minimizer-webpack-plugin'
 import { getBuildRoot, abs, getStaticPath, getDistPath, getSrcPath, getNeedCache } from '../utils/paths'
 import { BuildConfig, findBuildConfig, getNeedAnalyze } from '../utils/build-conf'
-import { addTransforms, svgoConfig } from './transform'
+import { addTransforms } from './transform'
 import { Env, getEnv } from '../utils/build-env'
 import logger from '../utils/logger'
 import { getPathFromUrl, getPageFilename } from '../utils'
 import { appendPlugins, processSourceMap, appendCacheGroups, parseOptimizationConfig, enableFilesystemCache } from '../utils/webpack'
+import { svgoConfigForImagemin } from '../utils/svgo'
 
 const dirnameOfBuilder = path.resolve(__dirname, '../..')
 const nodeModulesOfBuilder = path.resolve(dirnameOfBuilder, 'node_modules')
@@ -139,7 +140,7 @@ export async function getConfig(): Promise<Configuration> {
         plugins: [
           ['mozjpeg', { progressive: true, quality: 65 }],
           ['gifsicle', { interlaced: false }],
-          ['svgo', svgoConfig]
+          ['svgo', svgoConfigForImagemin]
           // 这里先不做 png 的压缩，因为 imagemin-pngquant 有可能会产生负优化（结果文件比源文件体积大），
           // 而且目前不支持 option 来在产生负优化时直接使用源文件，相关 issue https://github.com/kornelski/pngquant/issues/338
           // ['pngquant', { quality: [0.65, 0.9], speed: 4 }],
@@ -185,7 +186,7 @@ function getStaticDirCopyPlugin(buildConfig: BuildConfig) {
     return new CopyPlugin({
       patterns: [{ from: staticPath, to: 'static', toType: 'dir' }]
     })
-  } catch (e) {
-    logger.warn('Copy staticDir content failed:', e.message)
+  } catch (e: unknown) {
+    logger.warn('Copy staticDir content failed:', e && (e as any).message)
   }
 }

--- a/src/webpack/transform.ts
+++ b/src/webpack/transform.ts
@@ -3,6 +3,7 @@ import { Configuration, RuleSetRule } from 'webpack'
 import postcssPresetEnv from 'postcss-preset-env'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import { Transform } from '../constants/transform'
+import { getSvgoConfigForSvgr } from '../utils/svgo'
 import {
   BuildConfig, TransformObject, shouldAddGlobalPolyfill,
   AddPolyfill, shouldAddRuntimePolyfill
@@ -60,20 +61,6 @@ export function addTransforms(
   })
 
   return config
-}
-
-/** 对 svgo 的配置 */
-export const svgoConfig = {
-  plugins: [{
-    name: 'preset-default',
-    params: {
-      overrides: {
-        // removeViewBox 会导致指定了 width & height 的 svg 文件的 viewBox 被删掉，
-        // 而删掉 viewBox 会导致 svg 不能在外部指定 css 宽高时正确地缩放内容
-        removeViewBox: false
-      }
-    }
-  }]
 }
 
 interface TransformStyleConfig {
@@ -296,15 +283,12 @@ function addTransform(
 
     case Transform.Svgr: {
 
-      const svgrOptions = (
-        getEnv() === Env.Prod && optimization.compressImage
-        ? { svgo: true, svgoConfig }
-        : { svgo: false }
-      )
+      const shouldCompressSvg = getEnv() === Env.Prod && optimization.compressImage
+      const svgoConfig = getSvgoConfigForSvgr(shouldCompressSvg)
 
       return appendRuleWithLoaders(config, {
         loader: '@svgr/webpack',
-        options: svgrOptions
+        options: { svgo: true, svgoConfig }
       })
     }
 


### PR DESCRIPTION
### 问题表现

* 通过 svgr 引入的 svg 文件的处理逻辑（主要是压缩行为）不符合预期
* 同一个页面上不同 svg 中的同名定义（`id` 相同）会冲突，导致 svg 渲染错乱

### 细节说明

目前 builder 引入了两个不同版本的 svgo，一个是 1.x 版本（svgr 通过 `@svgr/plugin-svgo` 引入），一个是 2.x 版本（imagemin 通过 `imagemin-svgo` 引入）

在之前我们是用的同一份配置，但是 1.x 跟 2.x 对配置的格式要求是不同的，这也导致之前的 svgr 对 svg 文件的压缩行为是有问题的，因此这里分别配置；

P.S. 目前最新的 svgr 依赖的已经是 svgo 2.x，不过还是 beta 版本（6.0.0-beta.1），等 svgr 6.x 稳定后，可以通过升级 svgr（及其对应的 svgo）来统一两份配置；需要注意统一之后，用于 svgr 的 svgo 配置（处理后的 svg 会被 inline 到 DOM），跟用于 imagemin 的 svgo 配置（处理后的 svg 一般是作为独立的文件被加载的）可能还是会有区别，比如前者需要 `prefixIds` 逻辑，而后者不需要

此外，针对第二个问题，这里特别添加了对 svg 文件路径做 hash 并作为前缀拼接到 svg 中的元素的 `id` 上的逻辑，以避免不同的 svg 文件同时被 inline 到页面上时产生的定义冲突，效果如下：

源文件：

```xml
<path id="path-1" ... >
```

结果：

```xml
<path id="2cUTAZ43cI__path-1" ... >
```

每个 svg 中的不同元素会共享同一个 `id` 前缀

