### PR TITLE
调整文档中的小问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ v1.4.0 前的 Changelog：
 
 ##### 1.3.7
 
-支持省略项目目录下的 postcss.config.js 文件
+支持省略项目目录下的 postcss.config.js 文件
 
 ##### 1.3.6
 

--- a/build-config.md
+++ b/build-config.md
@@ -164,7 +164,7 @@ Build config 各个字段的定义。
 
 类型：`object`
 
-注入到代码中的环境变量，在扩展时会覆盖原值。如配置：
+注入到代码中的环境变量，在扩展时会合并原值。如配置：
 
 ```
 "API_PREFIX": "http://foobar.com/api"
@@ -298,7 +298,7 @@ const apiUrl = "http://foobar.com/api" + 'test'
 
 类型：`object`
 
-部署配置，在扩展时会合并原值，要求是一个 object，包含两个字段：`target` 及 `config`
+部署配置，在扩展时会覆盖原值，要求是一个 object，包含两个字段：`target` 及 `config`
 
 `deploy` 的字段描述如下：
 
@@ -334,7 +334,7 @@ const apiUrl = "http://foobar.com/api" + 'test'
 
 类型：`object`
 
-配置对构建环境的要求，在扩展时会覆盖原值。目前支持字段：`builder`
+配置对构建环境的要求，在扩展时会合并原值。目前支持字段：`builder`
 
 `engines` 的字段描述如下：
 

--- a/build-config.md
+++ b/build-config.md
@@ -173,7 +173,7 @@ Build config 各个字段的定义。
 则代码中：
 
 ```js
-const apiUrl = API + 'test'
+const apiUrl = API_PREFIX + 'test'
 ```
 
 会被转换为：

--- a/preset-configs/config.schema.json
+++ b/preset-configs/config.schema.json
@@ -88,7 +88,7 @@
     },
     "envVariables": {
       "type": "object",
-      "description": "注入到代码中的环境变量，在扩展时会合并原值。如配置：\n```\n\"API_PREFIX\": \"http://foobar.com/api\"\n```\n则代码中：\n```js\nconst apiUrl = API + 'test'\n```\n会被转换为：\n```js\nconst apiUrl = \"http://foobar.com/api\" + 'test'\n```"
+      "description": "注入到代码中的环境变量，在扩展时会合并原值。如配置：\n```\n\"API_PREFIX\": \"http://foobar.com/api\"\n```\n则代码中：\n```js\nconst apiUrl = API_PREFIX + 'test'\n```\n会被转换为：\n```js\nconst apiUrl = \"http://foobar.com/api\" + 'test'\n```"
     },
     "targets": {
       "type": "object",

--- a/preset-configs/config.schema.json
+++ b/preset-configs/config.schema.json
@@ -88,7 +88,7 @@
     },
     "envVariables": {
       "type": "object",
-      "description": "注入到代码中的环境变量，在扩展时会覆盖原值。如配置：\n```\n\"API_PREFIX\": \"http://foobar.com/api\"\n```\n则代码中：\n```js\nconst apiUrl = API + 'test'\n```\n会被转换为：\n```js\nconst apiUrl = \"http://foobar.com/api\" + 'test'\n```"
+      "description": "注入到代码中的环境变量，在扩展时会合并原值。如配置：\n```\n\"API_PREFIX\": \"http://foobar.com/api\"\n```\n则代码中：\n```js\nconst apiUrl = API + 'test'\n```\n会被转换为：\n```js\nconst apiUrl = \"http://foobar.com/api\" + 'test'\n```"
     },
     "targets": {
       "type": "object",
@@ -154,7 +154,7 @@
     },
     "deploy": {
       "type": "object",
-      "description": "部署配置，在扩展时会合并原值，要求是一个 object，包含两个字段：`target` 及 `config`",
+      "description": "部署配置，在扩展时会覆盖原值，要求是一个 object，包含两个字段：`target` 及 `config`",
       "properties": {
         "target": { "type": "string", "enum": ["qiniu"], "description": "部署目标" },
         "config": {
@@ -169,7 +169,7 @@
     },
     "engines": {
       "type": "object",
-      "description": "配置对构建环境的要求，在扩展时会覆盖原值。目前支持字段：`builder`",
+      "description": "配置对构建环境的要求，在扩展时会合并原值。目前支持字段：`builder`",
       "properties": {
         "builder": {
           "type": "string",


### PR DESCRIPTION
比如 build config 中的 `envVariables`，在 `extends` 时实际行为是合并，文档说明是覆盖；`deploy` & `engines` 则实际行为是覆盖，文档说明是合并

该文档会影响对应的 vscode 插件的提示结果