### PR TITLE
默认开启文件系统缓存

### DIFF
--- a/build-config.md
+++ b/build-config.md
@@ -304,6 +304,26 @@ const apiUrl = "http://foobar.com/api" + 'test'
 
     builder 默认提供粗粒度的 source map 以提升构建效率，效果上只是简单地将打包后代码按模块分开；开启 `highQualitySourceMap` 后，builder 会提供到源代码的映射，第三方依赖包自带的 source map 信息（如果有）也会被消费，以便为第三方库提供基于源代码的调试体验。
 
+- **`optimization.enableCache`**
+
+    是否启用文件系统缓存，用于提升二次启动的打包速度，对于大型的前端仓库提升效果尤其明显。
+
+    这里传入 `true` 表示所有环境均启用，`false` 则不启用；
+
+    也可以指定需要启用的环境列表，如传入 `["development"]`，表示仅在开发环境启用文件缓存。
+
+    `optimization.enableCache` 类型为以下几种之一：
+
+    - **`boolean`**
+
+        类型：`boolean`
+
+    - **`array`**
+
+        类型：`string[]`
+
+        指定要启用的环境列表，可选值有 `"development" | "production" | "test"`
+
 ## **`devProxy`**
 
 类型：`object`

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "fec-builder",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fec-builder",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "@babel/core": "^7.12.3",
         "@babel/plugin-proposal-class-properties": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fec-builder",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "bin": {
     "fec-builder": "./lib/bin.js"
   },

--- a/preset-configs/config.schema.json
+++ b/preset-configs/config.schema.json
@@ -158,6 +158,16 @@
         "highQualitySourceMap": {
           "type": "boolean",
           "description": "是否提供高质量的 source map。\nbuilder 默认提供粗粒度的 source map 以提升构建效率，效果上只是简单地将打包后代码按模块分开；开启 `highQualitySourceMap` 后，builder 会提供到源代码的映射，第三方依赖包自带的 source map 信息（如果有）也会被消费，以便为第三方库提供基于源代码的调试体验。"
+        },
+        "enableCache": {
+          "oneOf": [{
+            "type": "boolean"
+          }, {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "指定要启用的环境列表，可选值有 `\"development\" | \"production\" | \"test\"`"
+          }],
+          "description": "是否启用文件系统缓存，用于提升二次启动的打包速度，对于大型的前端仓库提升效果尤其明显。\n这里传入 `true` 表示所有环境均启用，`false` 则不启用；\n也可以指定需要启用的环境列表，如传入 `[\"development\"]`，表示仅在开发环境启用文件缓存。"
         }
       }
     },

--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -64,7 +64,8 @@
     "extractVendor": true,
     "compressImage": false,
     "transformDeps": false,
-    "highQualitySourceMap": false
+    "highQualitySourceMap": false,
+    "enableCache": ["development"]
   },
   "devProxy": {},
   "deploy": {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,7 +3,7 @@
 import { setAutoFreeze } from 'immer'
 import yargs from 'yargs'
 
-import { setBuildRoot, setBuildConfigFilePath, setNeedCache } from './utils/paths'
+import { setBuildRoot, setBuildConfigFilePath } from './utils/paths'
 import { Env, setEnv } from './utils/build-env'
 import logger from './utils/logger'
 import { setNeedAnalyze } from './utils/build-conf'
@@ -40,11 +40,6 @@ const options: Record<string, yargs.Options> = {
   verbose: {
     type: 'boolean',
     desc: 'Output more info',
-    default: false
-  },
-  'unstable-cache': {
-    type: 'boolean',
-    desc: 'Cache the generated webpack modules and chunks to filesystem for improve build speed. ',
     default: false
   }
 }
@@ -127,10 +122,6 @@ function applyArgv(argv: yargs.Arguments) {
     } else {
       setEnv(argv.BUILD_ENV as Env)
     }
-  }
-
-  if (argv['unstable-cache']) {
-    setNeedCache()
   }
 }
 

--- a/src/clean.ts
+++ b/src/clean.ts
@@ -9,20 +9,12 @@ import { getDistPath } from './utils/paths'
 import logger from './utils/logger'
 import { logLifecycle } from './utils'
 import { findBuildConfig } from './utils/build-conf'
-import { getNeedCache, getCachePath } from './utils/paths'
 
 async function clean() {
   const buildConfig = await findBuildConfig()
   const dist = getDistPath(buildConfig)
   logger.debug(`clean dist: ${dist}`)
   await del(dist, { force: true })
-
-  // delete webpack persistent cache directory
-  if (getNeedCache()) {
-    const cacheDir = getCachePath()
-    logger.debug(`clean cache: ${cacheDir}`)
-    await del(cacheDir, { force: true })
-  }
 }
 
 export default logLifecycle('Clean', clean, logger)

--- a/src/utils/build-conf.ts
+++ b/src/utils/build-conf.ts
@@ -6,6 +6,7 @@ import { extend, watchFile } from '.'
 import { getBuildConfigFilePath, abs, getBuildRoot } from './paths'
 import logger from './logger'
 import { Transform } from '../constants/transform'
+import { Env } from './build-env'
 
 export interface Engines {
   /** required builder version range */
@@ -53,6 +54,8 @@ export interface Optimization {
   addPolyfill: AddPolyfill
   /** 是否提供高质量的 source map */
   highQualitySourceMap: boolean
+  /** 是否启用文件缓存，dev 环境默认开启 */
+  enableCache: boolean | Env[]
 }
 
 export interface EnvVariables {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -61,14 +61,3 @@ export function getTestDistPath(conf: BuildConfig) {
 export function getCachePath() {
   return abs('node_modules/.cache/webpack')
 }
-
-/** whether need filesystem cache */
-let cache = false
-
-export function getNeedCache() {
-  return cache
-}
-
-export function setNeedCache() {
-  cache = true
-}

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -10,7 +10,7 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import WebpackBarPlugin from 'webpackbar'
 import ImageMinimizerPlugin from 'image-minimizer-webpack-plugin'
-import { getBuildRoot, abs, getStaticPath, getDistPath, getSrcPath, getNeedCache } from '../utils/paths'
+import { getBuildRoot, abs, getStaticPath, getDistPath, getSrcPath } from '../utils/paths'
 import { BuildConfig, findBuildConfig, getNeedAnalyze } from '../utils/build-conf'
 import { addTransforms } from './transform'
 import { Env, getEnv } from '../utils/build-env'
@@ -155,7 +155,8 @@ export async function getConfig(): Promise<Configuration> {
     }))
   }
 
-  if (getNeedCache()) {
+  const { enableCache } = buildConfig.optimization
+  if (enableCache === true || Array.isArray(enableCache) && enableCache.includes(getEnv())) {
     config = enableFilesystemCache(config)
   }
 


### PR DESCRIPTION
通过这段时间试用开启 `webpack` 的文件系统缓存，本地打包速提升带来的体验较好，且未发现该功能的缺陷，决定 `dev` 环境默认开启该功能。

<b>注意：`production` 环境不建议开启，项目需要在 `spock` 下打包时通常文件变动比较大使得缓存失效，测试下来在这个情况下对打包速度没多少提升，且生产环境以稳定性优化（参考备注的 pr 关联文档）。</b>

要覆盖默认的行为可在 `build-config.json` 中修改配置：
```
// 全部环境开启，设置为 `false` 则全部关闭
"optimization": {
  "enableCache": true
}

// 指定环境开启，也是当前的默认行为
"optimization": {
  "enableCache": ["development"]
}
```

---

之前支持该功能的 pr：https://github.com/Front-End-Engineering-Cloud/builder/pull/148