### PR TITLE
支持开关 error overlay

### DIFF
--- a/build-config.md
+++ b/build-config.md
@@ -312,6 +312,14 @@ const apiUrl = "http://foobar.com/api" + 'test'
 
     这里传入 `true` 表示启用文件系统缓存，`false` 则不启用。
 
+- **`optimization.errorOverlay`**
+
+    类型：`boolean`
+
+    是否开启 `react-refresh-webpack-plugin` 的错误提示。 
+
+    `true` 表示开启，`false` 表示关闭，默认关闭。
+
 ## **`devProxy`**
 
 类型：`object`

--- a/build-config.md
+++ b/build-config.md
@@ -318,7 +318,7 @@ const apiUrl = "http://foobar.com/api" + 'test'
 
     是否开启 `react-refresh-webpack-plugin` 的错误提示。 
 
-    `true` 表示开启，`false` 表示关闭，默认关闭。
+    `true` 表示开启，`false` 表示关闭，默认开启。
 
 ## **`devProxy`**
 

--- a/preset-configs/config.schema.json
+++ b/preset-configs/config.schema.json
@@ -162,6 +162,10 @@
         "filesystemCache": {
           "type": "boolean",
           "description": "是否启用文件系统缓存，用于提升二次启动的打包速度，对于大型的前端仓库提升效果尤其明显。\n这里传入 `true` 表示启用文件系统缓存，`false` 则不启用。"
+        },
+        "errorOverlay": {
+          "type": "boolean",
+          "description": "是否开启 `react-refresh-webpack-plugin` 的错误提示。 \n`true` 表示开启，`false` 表示关闭，默认关闭。"
         }
       }
     },

--- a/preset-configs/config.schema.json
+++ b/preset-configs/config.schema.json
@@ -165,7 +165,7 @@
         },
         "errorOverlay": {
           "type": "boolean",
-          "description": "是否开启 `react-refresh-webpack-plugin` 的错误提示。 \n`true` 表示开启，`false` 表示关闭，默认关闭。"
+          "description": "是否开启 `react-refresh-webpack-plugin` 的错误提示。 \n`true` 表示开启，`false` 表示关闭，默认开启。"
         }
       }
     },

--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -65,7 +65,8 @@
     "compressImage": false,
     "transformDeps": false,
     "highQualitySourceMap": false,
-    "filesystemCache": true
+    "filesystemCache": true,
+    "errorOverlay": true
   },
   "devProxy": {},
   "deploy": {

--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -66,7 +66,7 @@
     "transformDeps": false,
     "highQualitySourceMap": false,
     "filesystemCache": true,
-    "errorOverlay":  true
+    "errorOverlay": true
   },
   "devProxy": {},
   "deploy": {

--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -66,7 +66,7 @@
     "transformDeps": false,
     "highQualitySourceMap": false,
     "filesystemCache": true,
-    "errorOverlay": false
+    "errorOverlay":  true
   },
   "devProxy": {},
   "deploy": {

--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -66,7 +66,7 @@
     "transformDeps": false,
     "highQualitySourceMap": false,
     "filesystemCache": true,
-    "errorOverlay": true
+    "errorOverlay": false
   },
   "devProxy": {},
   "deploy": {

--- a/src/utils/build-conf.ts
+++ b/src/utils/build-conf.ts
@@ -55,6 +55,8 @@ export interface Optimization {
   highQualitySourceMap: boolean
   /** 是否启用文件系统缓存 */
   filesystemCache: boolean
+  /** 是否开启 react-refresh-webpack-plugin 的错误提示 */
+  errorOverlay: boolean
 }
 
 export interface EnvVariables {

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -164,10 +164,14 @@ export async function getConfig(): Promise<Configuration> {
 
 /** 获取 webpack 配置（dev server 用，不含 dev server 配置） */
 export async function getServeConfig() {
+  const buildConfig = await findBuildConfig()
+  const { errorOverlay } = buildConfig.optimization
   const config = await getConfig()
   return appendPlugins(
     config,
-    new ReactFastRefreshPlugin()
+    new ReactFastRefreshPlugin({
+      overlay: errorOverlay
+    })
   )
 }
 


### PR DESCRIPTION
<img width="1672" alt="wecom-temp-f70b2c9e3561e4b1f4e915acc7e89901" src="https://user-images.githubusercontent.com/3245316/151522126-e41d3558-8f48-44b4-b80b-107301d6fb69.png">

在开发测试阶段，对于一些预期的没有处理的错误，这个报错 super annoying

在 default.json 中默认关闭，需要使用的可以在项目的 build-config.json 中覆盖开启

### 其他

create-react-app 用的 error overlay，支持编辑器代码跳转
https://www.npmjs.com/package/error-overlay-webpack-plugin 

webpack 自带
https://webpack.js.org/configuration/dev-server/#overlay